### PR TITLE
[ScrollableControl] DisplayRectangle should include Padding.

### DIFF
--- a/src/Modern.Forms/ScrollableControl.cs
+++ b/src/Modern.Forms/ScrollableControl.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Drawing;
+using Modern.Forms.Layout;
 using Modern.Forms.Renderers;
 
 namespace Modern.Forms
@@ -113,6 +114,23 @@ namespace Modern.Forms
 
             canvas_size.Width = width;
             canvas_size.Height = height;
+        }
+
+        /// <inheritdoc/>
+        public override Rectangle DisplayRectangle {
+            get {
+                // A ScrollableControl DisplayRectangle includes Padding, while a normal Control does not.
+                var rect = ClientRectangle;
+
+                if (hscrollbar.Visible)
+                    rect.Height -= hscrollbar.Height;
+
+                if (vscrollbar.Visible)
+                    rect.Width -= vscrollbar.Width;
+
+                // TODO: Scale padding?
+                return LayoutUtils.DeflateRect (rect, Padding);
+            }
         }
 
         // Handles events from the scrollbars to update the window position.

--- a/tests/Modern.Forms.Tests/ControlTests.cs
+++ b/tests/Modern.Forms.Tests/ControlTests.cs
@@ -6,6 +6,65 @@ namespace Modern.Forms.Tests
     public class ControlTests
     {
         [Fact]
+        public void ClientSize ()
+        {
+            var control = new Control {
+                Width = 100,
+                Height = 100
+            };
+
+            Assert.Equal (100, control.ClientSize.Width);
+            Assert.Equal (100, control.ClientSize.Height);
+
+            control.Padding = new Padding (15);
+
+            Assert.Equal (100, control.ClientSize.Width);
+            Assert.Equal (100, control.ClientSize.Height);
+        }
+
+        [Fact]
+        public void ClientRectangle ()
+        {
+            var control = new Control {
+                Width = 100,
+                Height = 100
+            };
+
+            Assert.Equal (0, control.ClientRectangle.Left);
+            Assert.Equal (0, control.ClientRectangle.Top);
+            Assert.Equal (100, control.ClientRectangle.Width);
+            Assert.Equal (100, control.ClientRectangle.Height);
+
+            control.Padding = new Padding (15);
+
+            Assert.Equal (0, control.ClientRectangle.Left);
+            Assert.Equal (0, control.ClientRectangle.Top);
+            Assert.Equal (100, control.ClientRectangle.Width);
+            Assert.Equal (100, control.ClientRectangle.Height);
+        }
+
+        [Fact]
+        public void DisplayRectangle ()
+        {
+            var control = new Control {
+                Width = 100,
+                Height = 100
+            };
+
+            Assert.Equal (0, control.DisplayRectangle.Left);
+            Assert.Equal (0, control.DisplayRectangle.Top);
+            Assert.Equal (100, control.DisplayRectangle.Width);
+            Assert.Equal (100, control.DisplayRectangle.Height);
+
+            control.Padding = new Padding (15);
+
+            Assert.Equal (0, control.DisplayRectangle.Left);
+            Assert.Equal (0, control.DisplayRectangle.Top);
+            Assert.Equal (100, control.DisplayRectangle.Width);
+            Assert.Equal (100, control.DisplayRectangle.Height);
+        }
+
+        [Fact]
         public void GetNextControl_BasicTabIndex ()
         {
             var container = new Control ();

--- a/tests/Modern.Forms.Tests/ScrollableControlTests.cs
+++ b/tests/Modern.Forms.Tests/ScrollableControlTests.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using Xunit;
+
+namespace Modern.Forms.Tests
+{
+    public class ScrollableControlTests
+    {
+        [Fact]
+        public void ClientSize ()
+        {
+            var control = new ScrollableControl {
+                Width = 100,
+                Height = 100
+            };
+
+            Assert.Equal (100, control.ClientSize.Width);
+            Assert.Equal (100, control.ClientSize.Height);
+
+            control.Padding = new Padding (15);
+
+            Assert.Equal (100, control.ClientSize.Width);
+            Assert.Equal (100, control.ClientSize.Height);
+        }
+
+        [Fact]
+        public void ClientRectangle ()
+        {
+            var control = new ScrollableControl {
+                Width = 100,
+                Height = 100
+            };
+
+            Assert.Equal (0, control.ClientRectangle.Left);
+            Assert.Equal (0, control.ClientRectangle.Top);
+            Assert.Equal (100, control.ClientRectangle.Width);
+            Assert.Equal (100, control.ClientRectangle.Height);
+
+            control.Padding = new Padding (15);
+
+            Assert.Equal (0, control.ClientRectangle.Left);
+            Assert.Equal (0, control.ClientRectangle.Top);
+            Assert.Equal (100, control.ClientRectangle.Width);
+            Assert.Equal (100, control.ClientRectangle.Height);
+        }
+
+        [Fact]
+        public void DisplayRectangle ()
+        {
+            var control = new ScrollableControl {
+                Width = 100,
+                Height = 100
+            };
+
+            Assert.Equal (0, control.DisplayRectangle.Left);
+            Assert.Equal (0, control.DisplayRectangle.Top);
+            Assert.Equal (100, control.DisplayRectangle.Width);
+            Assert.Equal (100, control.DisplayRectangle.Height);
+
+            control.Padding = new Padding (15);
+
+            Assert.Equal (15, control.DisplayRectangle.Left);
+            Assert.Equal (15, control.DisplayRectangle.Top);
+            Assert.Equal (70, control.DisplayRectangle.Width);
+            Assert.Equal (70, control.DisplayRectangle.Height);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #43.

Matches Winforms `ScrollableControl` behavior.

I find it hard to believe this change doesn't break something, but I can't find anything that looks broken.  🤷‍♂️ 