### PR TITLE
Update to latest Modern.WindowKit changes.

### DIFF
--- a/samples/ControlGallery/Panels/ComboBoxPanel.cs
+++ b/samples/ControlGallery/Panels/ComboBoxPanel.cs
@@ -13,7 +13,7 @@ namespace ControlGallery.Panels
             var cb1 = Controls.Add (new ComboBox { Left = 10, Top = 35 });
             cb1.Items.AddRange (fruits);
 
-            var button = Controls.Add (new Button { Text = "Toggle", Left = 140, Top = 35 });
+            var button = Controls.Add (new Button { Text = "Open", Left = 140, Top = 35 });
             button.Click += (o, e) => cb1.DroppedDown = !cb1.DroppedDown;
 
             Controls.Add (new Label { Text = "Disabled", Left = 10, Top = 70, Width = 200 });

--- a/src/Modern.Forms/Clipboard.cs
+++ b/src/Modern.Forms/Clipboard.cs
@@ -13,7 +13,7 @@ namespace Modern.Forms
         /// <summary>
         /// Gets the contents of the clipboard as text.
         /// </summary>
-        public static Task<string> GetTextAsync () 
+        public static Task<string?> GetTextAsync () 
             => AvaloniaGlobals.GetRequiredService<IClipboard> ().GetTextAsync ();
 
         /// <summary>

--- a/src/Modern.Forms/Extensions/WindowKitExtensions.cs
+++ b/src/Modern.Forms/Extensions/WindowKitExtensions.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Modern.WindowKit.Input;
 using Modern.WindowKit.Platform.Storage;
+using Modern.WindowKit.Platform.Storage.FileIO;
 
 namespace Modern.Forms
 {
@@ -25,16 +26,16 @@ namespace Modern.Forms
 
         public static string? GetFullPath (this IStorageFile file)
         {
-            if (file.TryGetUri (out var uri))
-                return Path.GetFullPath (uri.LocalPath);
+            if (file is BclStorageFile path)
+                return path.FileInfo.FullName;
 
             return null;
         }
 
         public static string? GetFullPath (this IStorageFolder file)
         {
-            if (file.TryGetUri (out var uri))
-                return Path.GetFullPath (uri.LocalPath);
+            if (file is BclStorageFolder path)
+                return path.DirectoryInfo.FullName;
 
             return null;
         }

--- a/src/Modern.Forms/FileSystemDialog.cs
+++ b/src/Modern.Forms/FileSystemDialog.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.IO;
+using Modern.WindowKit.Platform.Storage.FileIO;
 
 namespace Modern.Forms
 {
@@ -16,5 +18,17 @@ namespace Modern.Forms
         /// Gets or sets the title for the dialog.
         /// </summary>
         public string Title { get; set; } = string.Empty;
+
+        internal BclStorageFolder? GetInitialDirectory ()
+        {
+            if (InitialDirectory is not null) {
+                var dir_info = new DirectoryInfo (InitialDirectory);
+
+                if (dir_info.Exists)
+                    return new BclStorageFolder (dir_info);
+            }
+
+            return null;
+        }
     }
 }

--- a/src/Modern.Forms/FolderBrowserDialog.cs
+++ b/src/Modern.Forms/FolderBrowserDialog.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Modern.WindowKit.Controls.Platform;
@@ -24,16 +25,16 @@ namespace Modern.Forms
         /// <param name="owner">The window that owns this dialog.</param>
         public async Task<DialogResult> ShowDialog (Form owner)
         {
-            if (owner.window is ITopLevelImplWithStorageProvider parent) {
+            if (owner.window.TryGetFeature (typeof (IStorageProvider)) is IStorageProvider parent) {
                 var options = new FolderPickerOpenOptions {
                     AllowMultiple = false,
-                    SuggestedStartLocation = InitialDirectory is not null ? new BclStorageFolder (InitialDirectory) : null,
+                    SuggestedStartLocation = GetInitialDirectory (),
                     Title = Title
                 };
 
-                var result = await parent.StorageProvider.OpenFolderPickerAsync (options);
+                var result = await parent.OpenFolderPickerAsync (options);
 
-                var paths = result.Select (f =>  f.GetFullPath ()).WhereNotNull ();
+                var paths = result.Select (f => f.GetFullPath ()).WhereNotNull ();
 
                 SelectedPath = paths?.FirstOrDefault ();
 

--- a/src/Modern.Forms/Form.cs
+++ b/src/Modern.Forms/Form.cs
@@ -38,7 +38,7 @@ namespace Modern.Forms
             Window.SetSystemDecorations (SystemDecorations.None);
             Window.SetExtendClientAreaToDecorationsHint (true);
 
-            Window.Closing = () => {
+            Window.Closing = (e) => {
                 var args = new CancelEventArgs ();
 
                 OnClosing (args);

--- a/src/Modern.Forms/Modern.Forms.csproj
+++ b/src/Modern.Forms/Modern.Forms.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="HarfBuzzSharp" Version="2.8.2.1" />
     <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="2.8.2.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="Modern.WindowKit" Version="[0.4.0-alpha01]" />
+    <PackageReference Include="Modern.WindowKit" Version="[0.4.0-alpha02]" />
     <PackageReference Include="Topten.RichTextKit" Version="0.4.151" />
   </ItemGroup>
 

--- a/src/Modern.Forms/OpenFileDialog.cs
+++ b/src/Modern.Forms/OpenFileDialog.cs
@@ -24,15 +24,15 @@ namespace Modern.Forms
         /// <param name="owner">The window that owns this dialog.</param>
         public async Task<DialogResult> ShowDialog (Form owner)
         {
-            if (owner.window is ITopLevelImplWithStorageProvider parent) {
+            if (owner.window.TryGetFeature (typeof (IStorageProvider)) is IStorageProvider parent) {
                 var options = new FilePickerOpenOptions {
                     AllowMultiple = AllowMultiple,
-                    SuggestedStartLocation = InitialDirectory is not null ? new BclStorageFolder (InitialDirectory) : null,
+                    SuggestedStartLocation = GetInitialDirectory (),
                     Title = Title,
                     FileTypeFilter = filters
                 };
 
-                var result = await parent.StorageProvider.OpenFilePickerAsync (options);
+                var result = await parent.OpenFilePickerAsync (options);
 
                 FileNames.Clear ();
 

--- a/src/Modern.Forms/PopupWindow.cs
+++ b/src/Modern.Forms/PopupWindow.cs
@@ -50,7 +50,7 @@ namespace Modern.Forms
                 Size = Size.ToAvaloniaSize ()
             };
 
-            PopupImpl.PopupPositioner.Update (ppp);
+            PopupImpl.PopupPositioner?.Update (ppp);
 
             Show ();
         }

--- a/src/Modern.Forms/SaveFileDialog.cs
+++ b/src/Modern.Forms/SaveFileDialog.cs
@@ -22,16 +22,16 @@ namespace Modern.Forms
         /// <param name="owner">The window that owns this dialog.</param>
         public async Task<DialogResult> ShowDialog (Form owner)
         {
-            if (owner.window is ITopLevelImplWithStorageProvider parent) {
+            if (owner.window.TryGetFeature (typeof (IStorageProvider)) is IStorageProvider parent) {
                 var options = new FilePickerSaveOptions {
                     DefaultExtension= DefaultExtension,
-                    SuggestedStartLocation = InitialDirectory is not null ? new BclStorageFolder (InitialDirectory) : null,
+                    SuggestedStartLocation = GetInitialDirectory (),
                     SuggestedFileName = FileName,
                     Title = Title,
                     FileTypeChoices = filters
                 };
 
-                var result = await parent.StorageProvider.SaveFilePickerAsync (options);
+                var result = await parent.SaveFilePickerAsync (options);
 
                 FileNames.Clear ();
 

--- a/src/Modern.Forms/WindowBase.cs
+++ b/src/Modern.Forms/WindowBase.cs
@@ -346,7 +346,7 @@ namespace Modern.Forms
             e.Canvas.DrawBackground (Bounds, CurrentStyle);
         }
 
-        private void OnResize (Size size, PlatformResizeReason reason)
+        private void OnResize (Size size, WindowResizeReason reason)
         {
             adapter.SetBounds (DisplayRectangle.Left, DisplayRectangle.Top, Size.Width, Size.Height);
         }


### PR DESCRIPTION
Tested on:
- [x] Windows 10 Normal DPI
- [x] Windows 11 Hi DPI
- [x] MacOS
- [x] Linux
  - [ ] Double titlebar (seems to be existing)
  - [ ] TextBox doesn't work (seems to be existing)