### PR TITLE
Add dark theme.

### DIFF
--- a/samples/ControlGallery/MainForm.cs
+++ b/samples/ControlGallery/MainForm.cs
@@ -151,8 +151,34 @@ namespace ControlGallery
         {
             base.OnPaint (e);
 
-            if (tree.SelectedItem.Text == "FormPaint")
+            if (tree.SelectedItem.Text == "FormPaint") {
                 e.Canvas.FillRectangle (Scale (300), Scale (50), Scale (100), Scale (100), SKColors.Red);
+
+                DrawThemeColor (e.Canvas, Scale (450), Scale (50), Scale (150), Scale (40), Theme.BackgroundColor);
+                DrawThemeColor (e.Canvas, Scale (450), Scale (90), Scale (150), Scale (40), Theme.ControlLowColor);
+                DrawThemeColor (e.Canvas, Scale (450), Scale (130), Scale (150), Scale (40), Theme.ControlMidColor);
+                DrawThemeColor (e.Canvas, Scale (450), Scale (170), Scale (150), Scale (40), Theme.ControlMidHighColor);
+                DrawThemeColor (e.Canvas, Scale (450), Scale (210), Scale (150), Scale (40), Theme.ControlHighColor);
+                DrawThemeColor (e.Canvas, Scale (450), Scale (250), Scale (150), Scale (40), Theme.ControlVeryHighColor);
+                DrawThemeColor (e.Canvas, Scale (450), Scale (290), Scale (150), Scale (40), Theme.ControlHighlightLowColor);
+                DrawThemeColor (e.Canvas, Scale (450), Scale (330), Scale (150), Scale (40), Theme.ControlHighlightMidColor);
+                DrawThemeColor (e.Canvas, Scale (450), Scale (370), Scale (150), Scale (40), Theme.ControlHighlightHighColor);
+                DrawThemeColor (e.Canvas, Scale (450), Scale (410), Scale (150), Scale (40), Theme.BorderLowColor);
+                DrawThemeColor (e.Canvas, Scale (450), Scale (450), Scale (150), Scale (40), Theme.BorderMidColor);
+                DrawThemeColor (e.Canvas, Scale (450), Scale (490), Scale (150), Scale (40), Theme.BorderHighColor);
+                DrawThemeColor (e.Canvas, Scale (450), Scale (530), Scale (150), Scale (40), Theme.ForegroundColor);
+                DrawThemeColor (e.Canvas, Scale (450), Scale (570), Scale (150), Scale (40), Theme.ForegroundDisabledColor);
+                DrawThemeColor (e.Canvas, Scale (450), Scale (610), Scale (150), Scale (40), Theme.ForegroundColorOnAccent);
+                DrawThemeColor (e.Canvas, Scale (450), Scale (650), Scale (150), Scale (40), Theme.AccentColor);
+                DrawThemeColor (e.Canvas, Scale (450), Scale (690), Scale (150), Scale (40), Theme.AccentColor2);
+                DrawThemeColor (e.Canvas, Scale (450), Scale (730), Scale (150), Scale (40), Theme.WarningHighlightColor);
+            }
+        }
+
+        private void DrawThemeColor (SKCanvas canvas, int x, int y, int width, int height, SKColor color)
+        {
+            canvas.FillRectangle (x, y, width, height, color);
+            canvas.DrawText (color.ToString (), x + 10, y + 20, new SKPaint { Typeface = Theme.UIFont, Color = Theme.ForegroundColor });
         }
 
         protected override void OnPaintBackground (PaintEventArgs e)

--- a/samples/ControlGallery/Panels/ButtonPanel.cs
+++ b/samples/ControlGallery/Panels/ButtonPanel.cs
@@ -28,7 +28,7 @@ namespace ControlGallery.Panels
             };
 
             b2.Style.BackgroundColor = SKColors.White;
-            b2.Style.ForegroundColor = Theme.PrimaryColor;
+            b2.Style.ForegroundColor = Theme.AccentColor2;
             b2.Style.Border.Width = 3;
             b2.Style.Border.Color = SKColors.Red;
 

--- a/samples/ControlGallery/Panels/MenuPanel.cs
+++ b/samples/ControlGallery/Panels/MenuPanel.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using Modern.Forms;
+using SkiaSharp;
 
 namespace ControlGallery.Panels
 {
@@ -39,6 +40,7 @@ namespace ControlGallery.Panels
             Controls.Add (menu);
 
             var label = Controls.Add (new Label { Left = 250, Top = 10, Width = 200, Height = 50 });
+            label.Style.BackgroundColor = SKColors.Transparent;
 
             foreach (var item in menu.Items)
                 HookUpEvent (item, label);

--- a/samples/ControlGallery/Panels/RadioButtonPanel.cs
+++ b/samples/ControlGallery/Panels/RadioButtonPanel.cs
@@ -15,8 +15,18 @@ namespace ControlGallery.Panels
             var panel = Controls.Add (new Panel { Left = 10, Top = 150, Width = 200, Height = 100 });
             panel.Style.Border.Width = 1;
 
-            panel.Controls.Add (new RadioButton { Text = "Hot", Left = 10, Top = 10, Checked = true });
-            panel.Controls.Add (new RadioButton { Text = "Cold", Left = 10, Top = 45 });
+            var light = panel.Controls.Add (new RadioButton { Text = "Light", Left = 10, Top = 10, Checked = true });
+            var dark = panel.Controls.Add (new RadioButton { Text = "Dark", Left = 10, Top = 45 });
+
+            light.CheckedChanged += (s, e) => {
+                if (light.Checked)
+                    Theme.SetBuiltInTheme (BuiltInTheme.Light);
+            };
+
+            dark.CheckedChanged += (s, e) => {
+                if (dark.Checked)
+                    Theme.SetBuiltInTheme (BuiltInTheme.Dark);
+            };
         }
     }
 }

--- a/samples/Explorer/MainForm.cs
+++ b/samples/Explorer/MainForm.cs
@@ -78,44 +78,41 @@ namespace Explore
         {
             var item = sender as MenuItem;
 
-            Theme.FormBackgroundColor = SKColors.White;
-            Theme.NeutralGray = new SKColor (240, 240, 240);
-            Theme.LightNeutralGray = new SKColor (251, 251, 251);
-            Theme.ItemHighlightColor = new SKColor (198, 198, 198);
+            Theme.SetBuiltInTheme (BuiltInTheme.Light);
 
             switch (item.Text) {
                 case "Default":
                     Theme.BeginUpdate ();
-                    Theme.HighlightColor = new SKColor (42, 138, 208);
-                    Theme.PrimaryColor = new SKColor (16, 110, 190);
+                    Theme.AccentColor = new SKColor (42, 138, 208);
+                    Theme.AccentColor2 = new SKColor (16, 110, 190);
                     Theme.EndUpdate ();
                     break;
                 case "Green":
                     Theme.BeginUpdate ();
-                    Theme.HighlightColor = new SKColor (67, 148, 103);
-                    Theme.PrimaryColor = new SKColor (33, 115, 70);
+                    Theme.AccentColor = new SKColor (67, 148, 103);
+                    Theme.AccentColor2 = new SKColor (33, 115, 70);
                     Theme.EndUpdate ();
                     break;
                 case "Orange":
                     Theme.BeginUpdate ();
-                    Theme.HighlightColor = new SKColor (220, 89, 57);
-                    Theme.PrimaryColor = new SKColor (183, 71, 42);
+                    Theme.AccentColor = new SKColor (220, 89, 57);
+                    Theme.AccentColor2 = new SKColor (183, 71, 42);
                     Theme.EndUpdate ();
                     break;
                 case "Purple":
                     Theme.BeginUpdate ();
-                    Theme.HighlightColor = new SKColor (163, 86, 158);
-                    Theme.PrimaryColor = new SKColor (128, 57, 123);
+                    Theme.AccentColor = new SKColor (163, 86, 158);
+                    Theme.AccentColor2 = new SKColor (128, 57, 123);
                     Theme.EndUpdate ();
                     break;
                 case "Hotdog Stand":
                     Theme.BeginUpdate ();
-                    Theme.HighlightColor = new SKColor (255, 128, 128);
-                    Theme.FormBackgroundColor = SKColors.Yellow;
-                    Theme.NeutralGray = SKColors.White;
-                    Theme.LightNeutralGray = new SKColor (255, 0, 0);
-                    Theme.ItemHighlightColor = new SKColor (255, 255, 255);
-                    Theme.PrimaryColor = new SKColor (255, 0, 0);
+                    Theme.AccentColor = new SKColor (255, 128, 128);
+                    Theme.BackgroundColor = SKColors.Yellow;
+                    Theme.ControlMidColor = SKColors.White;
+                    Theme.ControlLowColor = new SKColor (255, 0, 0);
+                    Theme.ControlHighlightLowColor = new SKColor (255, 255, 255);
+                    Theme.AccentColor2 = new SKColor (255, 0, 0);
                     Theme.EndUpdate ();
                     break;
             }

--- a/samples/Outlaw/MainForm.cs
+++ b/samples/Outlaw/MainForm.cs
@@ -12,7 +12,7 @@ namespace Outlaw
             PopulateEmailList ();
             email_list.DrawNode += EmailListDrawNode;
 
-            email_list.Style.SelectedItemBackgroundColor = Theme.DarkNeutralGray;
+            email_list.Style.SelectedItemBackgroundColor = Theme.ControlMidHighColor;
 
         }
 
@@ -22,7 +22,7 @@ namespace Outlaw
 
             if (item.Unread) {
                 var bounds = new Rectangle (item.Bounds.Left, item.Bounds.Top + e.LogicalToDeviceUnits (1), e.LogicalToDeviceUnits (3), item.Bounds.Height - e.LogicalToDeviceUnits (2));
-                e.Canvas.FillRectangle (bounds, Theme.PrimaryColor);
+                e.Canvas.FillRectangle (bounds, Theme.AccentColor2);
             }
 
             var line1_bounds = new Rectangle (item.Bounds.Left + e.LogicalToDeviceUnits (12), item.Bounds.Top + e.LogicalToDeviceUnits (3), item.Bounds.Width - e.LogicalToDeviceUnits (80), e.LogicalToDeviceUnits (23));
@@ -30,12 +30,12 @@ namespace Outlaw
             var line3_bounds = new Rectangle (item.Bounds.Left + e.LogicalToDeviceUnits (12), line2_bounds.Bottom - e.LogicalToDeviceUnits (3), item.Bounds.Width - e.LogicalToDeviceUnits (16), e.LogicalToDeviceUnits (20));
             var date_bounds = new Rectangle (item.Bounds.Width - e.LogicalToDeviceUnits (80), item.Bounds.Top + e.LogicalToDeviceUnits (3), e.LogicalToDeviceUnits (74), e.LogicalToDeviceUnits (23));
 
-            e.Canvas.DrawText (item.Text, Theme.UIFont, e.LogicalToDeviceUnits (16), line1_bounds, Theme.PrimaryTextColor, Modern.Forms.ContentAlignment.MiddleLeft, maxLines: e.LogicalToDeviceUnits (1));
+            e.Canvas.DrawText (item.Text, Theme.UIFont, e.LogicalToDeviceUnits (16), line1_bounds, Theme.ForegroundColor, Modern.Forms.ContentAlignment.MiddleLeft, maxLines: e.LogicalToDeviceUnits (1));
             e.Canvas.DrawText (item.Subject, Theme.UIFont, e.LogicalToDeviceUnits (12), line2_bounds, CustomTheme.LighterGrayFont, Modern.Forms.ContentAlignment.MiddleLeft, maxLines: e.LogicalToDeviceUnits (1));
             e.Canvas.DrawText (item.Body, Theme.UIFont, e.LogicalToDeviceUnits (12), line3_bounds, CustomTheme.LighterGrayFont, Modern.Forms.ContentAlignment.MiddleLeft, maxLines: e.LogicalToDeviceUnits (1));
             e.Canvas.DrawText (FormatDateTime (item.ReceiveDate), Theme.UIFont, e.LogicalToDeviceUnits (11), date_bounds, CustomTheme.LighterGrayFont, Modern.Forms.ContentAlignment.MiddleRight, maxLines: e.LogicalToDeviceUnits (1));
 
-            e.Canvas.DrawLine (item.Bounds.Left, item.Bounds.Bottom - e.LogicalToDeviceUnits (1), item.Bounds.Right, item.Bounds.Bottom - e.LogicalToDeviceUnits (1), Theme.NeutralGray, e.LogicalToDeviceUnits (1));
+            e.Canvas.DrawLine (item.Bounds.Left, item.Bounds.Bottom - e.LogicalToDeviceUnits (1), item.Bounds.Right, item.Bounds.Bottom - e.LogicalToDeviceUnits (1), Theme.ControlMidColor, e.LogicalToDeviceUnits (1));
         }
 
         private string FormatDateTime (DateTime date)

--- a/samples/Outlaw/Program.cs
+++ b/samples/Outlaw/Program.cs
@@ -10,7 +10,7 @@ namespace Outlaw
         [STAThread]
         public static void Main (string[] args)
         {
-            Theme.BorderGray = new SKColor (237, 235, 233);
+            Theme.BorderLowColor = new SKColor (237, 235, 233);
 
             var form = new MainForm ();
 

--- a/src/Modern.Forms/BorderStyle.cs
+++ b/src/Modern.Forms/BorderStyle.cs
@@ -114,7 +114,7 @@ namespace Modern.Forms
         /// <summary>
         /// Gets the computed color of this side of the border.
         /// </summary>
-        public SKColor GetColor () => Color ?? _parent?.GetColor () ?? Theme.BorderGray;
+        public SKColor GetColor () => Color ?? _parent?.GetColor () ?? Theme.BorderLowColor;
 
         /// <summary>
         /// Gets or sets the width of this side of the border.

--- a/src/Modern.Forms/BuiltInTheme.cs
+++ b/src/Modern.Forms/BuiltInTheme.cs
@@ -1,0 +1,22 @@
+﻿namespace Modern.Forms;
+
+/// <summary>
+/// Specifies a built-in system theme.
+/// </summary>
+public enum BuiltInTheme
+{
+    /// <summary>
+    /// Uses the built-in theme that matches the OS.
+    /// </summary>
+    Default,
+
+    /// <summary>
+    /// Uses the "Light" built-in theme.
+    /// </summary>
+    Light,
+
+    /// <summary>
+    /// Uses the "Dark" built-in theme.
+    /// </summary>
+    Dark
+}

--- a/src/Modern.Forms/Button.cs
+++ b/src/Modern.Forms/Button.cs
@@ -37,9 +37,9 @@ namespace Modern.Forms
         /// </summary>
         public new static ControlStyle DefaultStyleHover = new ControlStyle (DefaultStyle,
             (style) => {
-                style.BackgroundColor = Theme.HighlightColor;
-                style.Border.Color = Theme.PrimaryColor;
-                style.ForegroundColor = Theme.LightTextColor;
+                style.BackgroundColor = Theme.AccentColor;
+                style.Border.Color = Theme.AccentColor2;
+                style.ForegroundColor = Theme.ForegroundColorOnAccent;
             });
 
         /// <summary>

--- a/src/Modern.Forms/CheckBox.cs
+++ b/src/Modern.Forms/CheckBox.cs
@@ -66,8 +66,7 @@ namespace Modern.Forms
         /// <summary>
         /// The default ControlStyle for all instances of CheckBox.
         /// </summary>
-        public new static ControlStyle DefaultStyle = new ControlStyle (Control.DefaultStyle,
-            (style) => style.BackgroundColor = Theme.LightNeutralGray);
+        public new static ControlStyle DefaultStyle = new ControlStyle (Control.DefaultStyle);
 
         /// <summary>
         /// Raises the CheckedChanged event.

--- a/src/Modern.Forms/ComboBox.cs
+++ b/src/Modern.Forms/ComboBox.cs
@@ -37,7 +37,7 @@ namespace Modern.Forms
         public new static ControlStyle DefaultStyle = new ControlStyle (Control.DefaultStyle,
             (style) => {
                 style.Border.Width = 1;
-                style.BackgroundColor = Theme.DarkNeutralGray;
+                style.BackgroundColor = Theme.ControlMidColor;
             });
 
         /// <inheritdoc/>

--- a/src/Modern.Forms/Control.cs
+++ b/src/Modern.Forms/Control.cs
@@ -372,12 +372,12 @@ namespace Modern.Forms
         /// </summary>
         public static ControlStyle DefaultStyle = new ControlStyle (null,
             (style) => {
-                style.ForegroundColor = Theme.PrimaryTextColor;
-                style.BackgroundColor = Theme.NeutralGray;
+                style.ForegroundColor = Theme.ForegroundColor;
+                style.BackgroundColor = Theme.BackgroundColor;
                 style.Font = Theme.UIFont;
                 style.FontSize = Theme.FontSize;
                 style.Border.Radius = 0;
-                style.Border.Color = Theme.BorderGray;
+                style.Border.Color = Theme.BorderLowColor;
                 style.Border.Width = 0;
             });
 

--- a/src/Modern.Forms/ControlPaint.cs
+++ b/src/Modern.Forms/ControlPaint.cs
@@ -61,9 +61,9 @@ namespace Modern.Forms
         /// </summary>
         public static void DrawCheckBox (PaintEventArgs e, Rectangle rectangle, CheckState state, bool disabled = false)
         {
-            var color = disabled ? Theme.DisabledTextColor
-                            : state == CheckState.Checked && !disabled ? Theme.PrimaryColor
-                            : Theme.BorderGray;
+            var color = disabled ? Theme.ForegroundDisabledColor
+                            : state == CheckState.Checked && !disabled ? Theme.AccentColor
+                            : Theme.BorderLowColor;
             var unit_1 = e.LogicalToDeviceUnits (1);
 
             // Draw the border
@@ -95,8 +95,8 @@ namespace Modern.Forms
         /// </summary>
         public static void DrawCloseGlyph (PaintEventArgs e, Rectangle rectangle)
         {
-            e.Canvas.DrawLine (rectangle.X, rectangle.Y, rectangle.Right, rectangle.Bottom, Theme.LightTextColor);
-            e.Canvas.DrawLine (rectangle.X, rectangle.Bottom, rectangle.Right, rectangle.Y, Theme.LightTextColor);
+            e.Canvas.DrawLine (rectangle.X, rectangle.Y, rectangle.Right, rectangle.Bottom, Theme.ForegroundColorOnAccent);
+            e.Canvas.DrawLine (rectangle.X, rectangle.Bottom, rectangle.Right, rectangle.Y, Theme.ForegroundColorOnAccent);
         }
 
         /// <summary>
@@ -104,7 +104,7 @@ namespace Modern.Forms
         /// </summary>
         public static void DrawMaximizeGlyph (PaintEventArgs e, Rectangle rectangle)
         {
-            e.Canvas.DrawRectangle (rectangle, Theme.LightTextColor);
+            e.Canvas.DrawRectangle (rectangle, Theme.ForegroundColorOnAccent);
         }
 
         /// <summary>
@@ -112,7 +112,7 @@ namespace Modern.Forms
         /// </summary>
         public static void DrawMinimizeGlyph (PaintEventArgs e, Rectangle rectangle)
         {
-            e.Canvas.DrawLine (rectangle.X, rectangle.Y, rectangle.Right, rectangle.Y, Theme.LightTextColor);
+            e.Canvas.DrawLine (rectangle.X, rectangle.Y, rectangle.Right, rectangle.Y, Theme.ForegroundColorOnAccent);
         }
 
 
@@ -123,14 +123,14 @@ namespace Modern.Forms
         {
             var outer_radius = e.LogicalToDeviceUnits (8);
             var inner_radius = e.LogicalToDeviceUnits (5);
-            var border_color = disabled ? Theme.DisabledTextColor :
-                               state == CheckState.Checked ? Theme.PrimaryColor : 
-                               Theme.BorderGray;
+            var border_color = disabled ? Theme.ForegroundDisabledColor :
+                               state == CheckState.Checked ? Theme.AccentColor2 : 
+                               Theme.BorderLowColor;
 
             e.Canvas.DrawCircle (origin.X, origin.Y, outer_radius, border_color, e.LogicalToDeviceUnits (1));
 
             if (state == CheckState.Checked)
-                e.Canvas.FillCircle (origin.X, origin.Y, inner_radius, disabled ? Theme.DisabledTextColor : Theme.PrimaryColor);
+                e.Canvas.FillCircle (origin.X, origin.Y, inner_radius, disabled ? Theme.ForegroundDisabledColor : Theme.AccentColor2);
         }
     }
 }

--- a/src/Modern.Forms/ControlStyle.cs
+++ b/src/Modern.Forms/ControlStyle.cs
@@ -64,7 +64,7 @@ namespace Modern.Forms
         /// <summary>
         /// Gets the computed background color.
         /// </summary>
-        public SKColor GetBackgroundColor () => BackgroundColor ?? _parent?.GetBackgroundColor () ?? Theme.NeutralGray;
+        public SKColor GetBackgroundColor () => BackgroundColor ?? _parent?.GetBackgroundColor () ?? Theme.ControlMidColor;
 
         /// <summary>
         /// Gets the computed font.
@@ -79,6 +79,6 @@ namespace Modern.Forms
         /// <summary>
         /// Gets the computed foreground color.
         /// </summary>
-        public SKColor GetForegroundColor () => ForegroundColor ?? _parent?.GetForegroundColor () ?? Theme.PrimaryTextColor;
+        public SKColor GetForegroundColor () => ForegroundColor ?? _parent?.GetForegroundColor () ?? Theme.ForegroundColor;
     }
 }

--- a/src/Modern.Forms/Extensions/SkiaTextExtensions.cs
+++ b/src/Modern.Forms/Extensions/SkiaTextExtensions.cs
@@ -16,7 +16,7 @@ namespace Modern.Forms
         /// Draws a string of text.
         /// </summary>
         public static void DrawText (this SKCanvas canvas, string text, Rectangle bounds, Control control, ContentAlignment alignment, int selectionStart = -1, int selectionEnd = -1, SKColor? selectionColor = null, int? maxLines = null, bool ellipsis = false)
-            => canvas.DrawText (text, control.CurrentStyle.GetFont (), control.LogicalToDeviceUnits (control.CurrentStyle.GetFontSize ()), bounds, control.Enabled ? control.CurrentStyle.GetForegroundColor () : Theme.DisabledTextColor, alignment, selectionStart, selectionEnd, selectionColor, maxLines, ellipsis);
+            => canvas.DrawText (text, control.CurrentStyle.GetFont (), control.LogicalToDeviceUnits (control.CurrentStyle.GetFontSize ()), bounds, control.Enabled ? control.CurrentStyle.GetForegroundColor () : Theme.ForegroundDisabledColor, alignment, selectionStart, selectionEnd, selectionColor, maxLines, ellipsis);
 
         /// <summary>
         /// Draws a string of text.
@@ -69,6 +69,6 @@ namespace Modern.Forms
         /// Draws a single line of text.
         /// </summary>
         public static void DrawTextLine (this SKCanvas canvas, string text, Rectangle bounds, Control control, ContentAlignment alignment, bool ellipsis = false)
-            => canvas.DrawText (text, control.CurrentStyle.GetFont (), control.LogicalToDeviceUnits (control.CurrentStyle.GetFontSize ()), bounds, control.Enabled ? control.CurrentStyle.GetForegroundColor () : Theme.DisabledTextColor, alignment, maxLines: 1, ellipsis: ellipsis);
+            => canvas.DrawText (text, control.CurrentStyle.GetFont (), control.LogicalToDeviceUnits (control.CurrentStyle.GetFontSize ()), bounds, control.Enabled ? control.CurrentStyle.GetForegroundColor () : Theme.ForegroundDisabledColor, alignment, maxLines: 1, ellipsis: ellipsis);
     }
 }

--- a/src/Modern.Forms/Form.cs
+++ b/src/Modern.Forms/Form.cs
@@ -84,7 +84,7 @@ namespace Modern.Forms
         /// <inheritdoc/>
         public override void Close ()
         {
-            Application.OpenForms.Remove(this);
+            Application.OpenForms.Remove (this);
             base.Close ();
 
             // If this was a dialog box we need to reactivate the parent
@@ -115,8 +115,8 @@ namespace Modern.Forms
         /// </summary>
         public new static ControlStyle DefaultStyle = new ControlStyle (Control.DefaultStyle,
          (style) => {
-             style.BackgroundColor = Theme.FormBackgroundColor;
-             style.Border.Color = Theme.PrimaryColor;
+             style.BackgroundColor = Theme.BackgroundColor;
+             style.Border.Color = Theme.AccentColor2;
              style.Border.Width = 1;
          });
 
@@ -416,7 +416,7 @@ namespace Modern.Forms
             set {
                 if (shown)
                     throw new InvalidOperationException ($"Cannot change {nameof (UseSystemDecorations)} once a Form has been shown.");
-                
+
                 if (use_system_decorations != value) {
                     use_system_decorations = value;
                     TitleBar.Visible = !use_system_decorations;

--- a/src/Modern.Forms/FormTitleBar.cs
+++ b/src/Modern.Forms/FormTitleBar.cs
@@ -84,7 +84,7 @@ namespace Modern.Forms
 
         /// <inheritdoc/>
         public new static ControlStyle DefaultStyle = new ControlStyle (Control.DefaultStyle,
-           (style) => style.BackgroundColor = Theme.PrimaryColor);
+           (style) => style.BackgroundColor = Theme.AccentColor2);
 
         /// <summary>
         /// Gets or sets the image used as the upper-left icon of the titlebar.
@@ -167,7 +167,7 @@ namespace Modern.Forms
                 base.OnPaint (e);
 
                 if (IsHovering)
-                    e.Canvas.Clear (glyph == TitleBarButtonGlyph.Close ? Theme.FormCloseHighlightColor : Theme.HighlightColor);
+                    e.Canvas.Clear (glyph == TitleBarButtonGlyph.Close ? Theme.WarningHighlightColor : Theme.AccentColor);
 
                 var glyph_bounds = glyph == TitleBarButtonGlyph.Minimize ?
                     DrawingExtensions.CenterRectangle (ClientRectangle, e.LogicalToDeviceUnits (new Size (BUTTON_PADDING, 1))) :

--- a/src/Modern.Forms/ListBox.cs
+++ b/src/Modern.Forms/ListBox.cs
@@ -50,7 +50,7 @@ namespace Modern.Forms
         /// <inheritdoc/>
         public new static ControlStyle DefaultStyle = new ControlStyle (Control.DefaultStyle,
             (style) => {
-                style.BackgroundColor = Theme.LightNeutralGray;
+                style.BackgroundColor = Theme.ControlLowColor;
                 style.Border.Width = 1;
             });
 

--- a/src/Modern.Forms/ListView.cs
+++ b/src/Modern.Forms/ListView.cs
@@ -27,7 +27,7 @@ namespace Modern.Forms
 
         /// <inheritdoc/>
         public new static ControlStyle DefaultStyle = new ControlStyle (Control.DefaultStyle, 
-            (style) => style.BackgroundColor = Theme.LightNeutralGray);
+            (style) => style.BackgroundColor = Theme.ControlLowColor);
 
         /// <summary>
         /// Raised when a list view item is double-clicked.

--- a/src/Modern.Forms/Menu.cs
+++ b/src/Modern.Forms/Menu.cs
@@ -23,7 +23,7 @@ namespace Modern.Forms
         /// <inheritdoc/>
         public new static ControlStyle DefaultStyle = new ControlStyle (Control.DefaultStyle,
           (style) => {
-              style.BackgroundColor = Theme.NeutralGray;
+              style.BackgroundColor = Theme.ControlMidColor;
           });
 
         /// <inheritdoc/>

--- a/src/Modern.Forms/Menu.cs
+++ b/src/Modern.Forms/Menu.cs
@@ -21,10 +21,7 @@ namespace Modern.Forms
         protected override Size DefaultSize => new Size (600, 28);
 
         /// <inheritdoc/>
-        public new static ControlStyle DefaultStyle = new ControlStyle (Control.DefaultStyle,
-          (style) => {
-              style.BackgroundColor = Theme.ControlMidColor;
-          });
+        public new static ControlStyle DefaultStyle = new ControlStyle (Control.DefaultStyle);
 
         /// <inheritdoc/>
         protected override bool IsTopLevelMenu => true;

--- a/src/Modern.Forms/MenuDropDown.cs
+++ b/src/Modern.Forms/MenuDropDown.cs
@@ -47,7 +47,7 @@ namespace Modern.Forms
         /// <inheritdoc/>
         public new static ControlStyle DefaultStyle = new ControlStyle (Control.DefaultStyle,
             (style) => {
-                style.BackgroundColor = Theme.ItemHighlightColor;
+                style.BackgroundColor = Theme.ControlMidColor;
                 style.Border.Width = 1;
             });
 

--- a/src/Modern.Forms/MessageBoxForm.cs
+++ b/src/Modern.Forms/MessageBoxForm.cs
@@ -35,7 +35,7 @@ namespace Modern.Forms
                 Height = 45
             });
 
-            label.Style.BackgroundColor = Theme.FormBackgroundColor;
+            label.Style.BackgroundColor = Theme.BackgroundColor;
             label.Style.Border.Width = 0;
 
             ok_button = label_panel.Controls.Add (new Button {

--- a/src/Modern.Forms/NavigationPane.cs
+++ b/src/Modern.Forms/NavigationPane.cs
@@ -25,9 +25,9 @@ public class NavigationPane : Control
     /// <inheritdoc/>
     public new static ControlStyle DefaultStyle = new ControlStyle (Control.DefaultStyle,
         (style) => {
-            style.BackgroundColor = Theme.NeutralGray;
+            style.BackgroundColor = Theme.ControlMidColor;
             style.Border.Right.Width = 1;
-            style.Border.Right.Color = new SkiaSharp.SKColor (237, 235, 233);
+            style.Border.Right.Color = Theme.BorderLowColor;
         });
 
     // Returns the item at the specified location.

--- a/src/Modern.Forms/PopupWindow.cs
+++ b/src/Modern.Forms/PopupWindow.cs
@@ -28,7 +28,10 @@ namespace Modern.Forms
         /// <summary>
         /// Gets the default style for all controls of this type.
         /// </summary>
-        public new static ControlStyle DefaultStyle = new ControlStyle (Control.DefaultStyle);
+        public new static ControlStyle DefaultStyle = new ControlStyle (Control.DefaultStyle,
+            (style) => {
+                style.BackgroundColor = Theme.ControlMidColor;
+            });
 
         private IPopupImpl PopupImpl => (IPopupImpl)window;
 

--- a/src/Modern.Forms/RadioButton.cs
+++ b/src/Modern.Forms/RadioButton.cs
@@ -55,8 +55,7 @@ namespace Modern.Forms
         protected override Size DefaultSize => new Size (104, 24);
 
         /// <inheritdoc/>
-        public new static ControlStyle DefaultStyle = new ControlStyle (Control.DefaultStyle,
-            (style) => style.BackgroundColor = Theme.LightNeutralGray);
+        public new static ControlStyle DefaultStyle = new ControlStyle (Control.DefaultStyle);
 
         /// <summary>
         /// Raises the CheckedChanged event.

--- a/src/Modern.Forms/Renderers/ComboBoxRenderer.cs
+++ b/src/Modern.Forms/Renderers/ComboBoxRenderer.cs
@@ -31,7 +31,7 @@ namespace Modern.Forms.Renderers
             // Draw the drop down glyph
             var button_bounds = GetDropDownButtonArea (control, e);
 
-            ControlPaint.DrawArrowGlyph (e, button_bounds, control.Enabled ? Theme.PrimaryTextColor : Theme.DisabledTextColor, ArrowDirection.Down);
+            ControlPaint.DrawArrowGlyph (e, button_bounds, control.Enabled ? Theme.ForegroundColor : Theme.ForegroundDisabledColor, ArrowDirection.Down);
         }
 
         /// <summary>

--- a/src/Modern.Forms/Renderers/FormTitleBarRenderer.cs
+++ b/src/Modern.Forms/Renderers/FormTitleBarRenderer.cs
@@ -12,7 +12,7 @@ namespace Modern.Forms.Renderers
         protected override void Render (FormTitleBar control, PaintEventArgs e)
         {
             // Form text
-            e.Canvas.DrawText (control.Text.Trim (), Theme.UIFont, e.LogicalToDeviceUnits (Theme.FontSize), control.ScaledBounds, Theme.LightTextColor, ContentAlignment.MiddleCenter);
+            e.Canvas.DrawText (control.Text.Trim (), Theme.UIFont, e.LogicalToDeviceUnits (Theme.FontSize), control.ScaledBounds, Theme.ForegroundColorOnAccent, ContentAlignment.MiddleCenter);
         }
     }
 }

--- a/src/Modern.Forms/Renderers/ListBoxRenderer.cs
+++ b/src/Modern.Forms/Renderers/ListBoxRenderer.cs
@@ -34,11 +34,11 @@ namespace Modern.Forms.Renderers
         {
             // Draw selected background
             if (control.Items.SelectedIndexes.Contains (index))
-                e.Canvas.FillRectangle (bounds, Theme.ItemHighlightColor);
+                e.Canvas.FillRectangle (bounds, Theme.ControlHighlightLowColor);
 
             // Draw hover background
             else if (control.ShowHover && control.Items.HoveredIndex == index)
-                e.Canvas.FillRectangle (bounds, Theme.NeutralGray);
+                e.Canvas.FillRectangle (bounds, Theme.ControlMidColor);
 
             // Draw focus rectangle
             if (control.Selected && control.ShowFocusCues && control.Items.FocusedIndex == index)

--- a/src/Modern.Forms/Renderers/ListViewRenderer.cs
+++ b/src/Modern.Forms/Renderers/ListViewRenderer.cs
@@ -21,7 +21,7 @@ namespace Modern.Forms.Renderers
         protected virtual void RenderItem (ListView control, ListViewItem item, PaintEventArgs e)
         {
             if (item.Selected)
-                e.Canvas.FillRectangle (item.Bounds, Theme.ItemHighlightColor);
+                e.Canvas.FillRectangle (item.Bounds, Theme.ControlHighlightLowColor);
 
             var image_size = e.LogicalToDeviceUnits (32);
             var image_area = new Rectangle (item.Bounds.Left, item.Bounds.Top, item.Bounds.Width, item.Bounds.Width);
@@ -39,7 +39,7 @@ namespace Modern.Forms.Renderers
 
                 var text_bounds = new Rectangle (item.Bounds.Left, image_bounds.Bottom + e.LogicalToDeviceUnits (3), item.Bounds.Width, item.Bounds.Bottom - image_bounds.Bottom - e.LogicalToDeviceUnits (3));
 
-                e.Canvas.DrawText (item.Text, Theme.UIFont, font_size, text_bounds, Theme.PrimaryTextColor, ContentAlignment.MiddleCenter);
+                e.Canvas.DrawText (item.Text, Theme.UIFont, font_size, text_bounds, Theme.ForegroundColor, ContentAlignment.MiddleCenter);
 
                 e.Canvas.Restore ();
             }

--- a/src/Modern.Forms/Renderers/MenuDropDownRenderer.cs
+++ b/src/Modern.Forms/Renderers/MenuDropDownRenderer.cs
@@ -24,7 +24,7 @@ namespace Modern.Forms.Renderers
         protected virtual void RenderItem (MenuDropDown control, MenuItem item, PaintEventArgs e)
         {
             // Background
-            var background_color = item.Hovered || item.IsDropDownOpened ? Theme.ItemHighlightColor : Theme.LightTextColor;
+            var background_color = item.Hovered || item.IsDropDownOpened ? Theme.ControlHighlightLowColor : Theme.ForegroundColorOnAccent;
             e.Canvas.FillRectangle (item.Bounds, background_color);
 
             // Image
@@ -36,7 +36,7 @@ namespace Modern.Forms.Renderers
             }
 
             // Text
-            var font_color = item.Enabled ? Theme.PrimaryTextColor : Theme.DisabledTextColor;
+            var font_color = item.Enabled ? Theme.ForegroundColor : Theme.ForegroundDisabledColor;
             var font_size = e.LogicalToDeviceUnits (Theme.FontSize);
             var bounds = item.Bounds;
             bounds.X += e.LogicalToDeviceUnits (28);
@@ -56,13 +56,13 @@ namespace Modern.Forms.Renderers
         protected virtual void RenderMenuSeparatorItem (MenuDropDown control, MenuSeparatorItem item, PaintEventArgs e)
         {
             // Background
-            e.Canvas.FillRectangle (item.Bounds, Theme.LightTextColor);
+            e.Canvas.FillRectangle (item.Bounds, Theme.ForegroundColorOnAccent);
 
             var center = item.Bounds.GetCenter ();
             var thickness = e.LogicalToDeviceUnits (1);
             var padding = e.LogicalToDeviceUnits (item.Padding);
 
-            e.Canvas.DrawLine (item.Bounds.X + padding.Top, center.Y, item.Bounds.Right - padding.Right, center.Y, item.Enabled ? Theme.ItemHighlightColor : Theme.DisabledTextColor, thickness);
+            e.Canvas.DrawLine (item.Bounds.X + padding.Top, center.Y, item.Bounds.Right - padding.Right, center.Y, item.Enabled ? Theme.ControlHighlightLowColor : Theme.ForegroundDisabledColor, thickness);
         }
 
         /// <summary>

--- a/src/Modern.Forms/Renderers/MenuDropDownRenderer.cs
+++ b/src/Modern.Forms/Renderers/MenuDropDownRenderer.cs
@@ -24,7 +24,7 @@ namespace Modern.Forms.Renderers
         protected virtual void RenderItem (MenuDropDown control, MenuItem item, PaintEventArgs e)
         {
             // Background
-            var background_color = item.Hovered || item.IsDropDownOpened ? Theme.ControlHighlightLowColor : Theme.ForegroundColorOnAccent;
+            var background_color = item.Hovered || item.IsDropDownOpened ? Theme.ControlHighlightLowColor : Theme.ControlLowColor;
             e.Canvas.FillRectangle (item.Bounds, background_color);
 
             // Image
@@ -56,7 +56,7 @@ namespace Modern.Forms.Renderers
         protected virtual void RenderMenuSeparatorItem (MenuDropDown control, MenuSeparatorItem item, PaintEventArgs e)
         {
             // Background
-            e.Canvas.FillRectangle (item.Bounds, Theme.ForegroundColorOnAccent);
+            e.Canvas.FillRectangle (item.Bounds, Theme.ControlLowColor);
 
             var center = item.Bounds.GetCenter ();
             var thickness = e.LogicalToDeviceUnits (1);

--- a/src/Modern.Forms/Renderers/MenuRenderer.cs
+++ b/src/Modern.Forms/Renderers/MenuRenderer.cs
@@ -24,11 +24,11 @@ namespace Modern.Forms.Renderers
         protected virtual void RenderItem (Menu control, MenuItem item, PaintEventArgs e)
         {
             // Background
-            var background_color = item.Hovered || item.IsDropDownOpened ? Theme.ItemHighlightColor : Theme.NeutralGray;
+            var background_color = item.Hovered || item.IsDropDownOpened ? Theme.ControlHighlightLowColor : Theme.ControlMidColor;
             e.Canvas.FillRectangle (item.Bounds, background_color);
 
             // Text
-            var font_color = item.Enabled ? Theme.PrimaryTextColor : Theme.DisabledTextColor;
+            var font_color = item.Enabled ? Theme.ForegroundColor : Theme.ForegroundDisabledColor;
             var font_size = e.LogicalToDeviceUnits (Theme.FontSize);
 
             e.Canvas.DrawText (item.Text, Theme.UIFont, font_size, item.Bounds, font_color, ContentAlignment.MiddleCenter);
@@ -40,13 +40,13 @@ namespace Modern.Forms.Renderers
         protected virtual void RenderMenuSeparatorItem (Menu control, MenuSeparatorItem item, PaintEventArgs e)
         {
             // Background
-            e.Canvas.FillRectangle (item.Bounds, Theme.NeutralGray);
+            e.Canvas.FillRectangle (item.Bounds, Theme.ControlMidColor);
 
             var center = item.Bounds.GetCenter ();
             var thickness = e.LogicalToDeviceUnits (1);
             var padding = e.LogicalToDeviceUnits (item.Padding);
 
-            e.Canvas.DrawLine (center.X, item.Bounds.Top + padding.Top, center.X, item.Bounds.Bottom - padding.Bottom, item.Enabled ? Theme.ItemHighlightColor : Theme.DisabledTextColor, thickness);
+            e.Canvas.DrawLine (center.X, item.Bounds.Top + padding.Top, center.X, item.Bounds.Bottom - padding.Bottom, item.Enabled ? Theme.ControlHighlightLowColor : Theme.ForegroundDisabledColor, thickness);
         }
 
         /// <summary>

--- a/src/Modern.Forms/Renderers/MenuRenderer.cs
+++ b/src/Modern.Forms/Renderers/MenuRenderer.cs
@@ -24,7 +24,7 @@ namespace Modern.Forms.Renderers
         protected virtual void RenderItem (Menu control, MenuItem item, PaintEventArgs e)
         {
             // Background
-            var background_color = item.Hovered || item.IsDropDownOpened ? Theme.ControlHighlightLowColor : Theme.ControlMidColor;
+            var background_color = item.Hovered || item.IsDropDownOpened ? Theme.ControlHighlightLowColor : Theme.BackgroundColor;
             e.Canvas.FillRectangle (item.Bounds, background_color);
 
             // Text
@@ -40,7 +40,7 @@ namespace Modern.Forms.Renderers
         protected virtual void RenderMenuSeparatorItem (Menu control, MenuSeparatorItem item, PaintEventArgs e)
         {
             // Background
-            e.Canvas.FillRectangle (item.Bounds, Theme.ControlMidColor);
+            e.Canvas.FillRectangle (item.Bounds, Theme.BackgroundColor);
 
             var center = item.Bounds.GetCenter ();
             var thickness = e.LogicalToDeviceUnits (1);

--- a/src/Modern.Forms/Renderers/NavigationPaneRenderer.cs
+++ b/src/Modern.Forms/Renderers/NavigationPaneRenderer.cs
@@ -21,13 +21,13 @@ public class NavigationPaneRenderer : Renderer<NavigationPane>
     protected virtual void RenderItem (NavigationPane control, NavigationPaneItem item, PaintEventArgs e)
     {
         if (item.Hovered && item.Enabled)
-            e.Canvas.FillRectangle (item.Bounds, Theme.LightNeutralGray);
+            e.Canvas.FillRectangle (item.Bounds, Theme.ControlLowColor);
 
         // Draw focus rectangle
         if (control.Selected && control.ShowFocusCues && control.Items.FocusedIndex == control.Items.IndexOf (item))
             e.Canvas.DrawFocusRectangle (item.Bounds, e.LogicalToDeviceUnits (1));
 
-        var font_color = !item.Enabled ? Theme.DisabledTextColor : Theme.PrimaryTextColor;
+        var font_color = !item.Enabled ? Theme.ForegroundDisabledColor : Theme.ForegroundColor;
         var font = item.Selected || item.Hovered ? Theme.UIFontBold : Theme.UIFont;
         var font_size = e.LogicalToDeviceUnits (Theme.FontSize);
 
@@ -43,7 +43,7 @@ public class NavigationPaneRenderer : Renderer<NavigationPane>
             var highlight_padding = e.LogicalToDeviceUnits (3);
             var highlight_bounds = new Rectangle (item.Bounds.Left - highlight_width, item.Bounds.Top + highlight_padding, highlight_width, item.Bounds.Height - (2 * highlight_padding));
             
-            e.Canvas.FillRectangle (highlight_bounds, Theme.PrimaryColor);
+            e.Canvas.FillRectangle (highlight_bounds, Theme.AccentColor2);
         }
     }
 }

--- a/src/Modern.Forms/Renderers/ProgressBarRenderer.cs
+++ b/src/Modern.Forms/Renderers/ProgressBarRenderer.cs
@@ -19,7 +19,7 @@ namespace Modern.Forms.Renderers
             var filled_pixels = (int)(percent * client_area.Width);
 
             if (filled_pixels > 0)
-                e.Canvas.FillRectangle (client_area.X, client_area.Y, filled_pixels, client_area.Height, control.Enabled ? Theme.PrimaryColor : Theme.DisabledTextColor);
+                e.Canvas.FillRectangle (client_area.X, client_area.Y, filled_pixels, client_area.Height, control.Enabled ? Theme.AccentColor2 : Theme.ForegroundDisabledColor);
         }
     }
 }

--- a/src/Modern.Forms/Renderers/RibbonRenderer.cs
+++ b/src/Modern.Forms/Renderers/RibbonRenderer.cs
@@ -33,7 +33,7 @@ namespace Modern.Forms.Renderers
         {
             LayoutTabPage (tabPage);
 
-            e.Canvas.FillRectangle (tabPage.Bounds, Theme.NeutralGray);
+            e.Canvas.FillRectangle (tabPage.Bounds, Theme.ControlMidColor);
 
             foreach (var group in tabPage.Groups)
                 RenderItemGroup (control, tabPage, group, e);
@@ -52,7 +52,7 @@ namespace Modern.Forms.Renderers
                     RenderItem (control, tabPage, group, item, e);
 
             // Right border (group separator)
-            e.Canvas.DrawLine (group.Bounds.Right - 1, group.Bounds.Top + 4, group.Bounds.Right - 1, group.Bounds.Bottom - 4, Theme.BorderGray);
+            e.Canvas.DrawLine (group.Bounds.Right - 1, group.Bounds.Top + 4, group.Bounds.Right - 1, group.Bounds.Bottom - 4, Theme.BorderLowColor);
         }
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace Modern.Forms.Renderers
         {
             var canvas = e.Canvas;
             var padding = e.LogicalToDeviceUnits (item.Padding);
-            var background_color = item.Selected ? Theme.ItemSelectedColor : item.Hovered ? Theme.ItemHighlightColor : Theme.NeutralGray;
+            var background_color = item.Selected ? Theme.ControlHighlightMidColor : item.Hovered ? Theme.ControlHighlightLowColor : Theme.ControlMidColor;
 
             canvas.FillRectangle (item.Bounds, background_color);
 
@@ -79,7 +79,7 @@ namespace Modern.Forms.Renderers
                 canvas.Clip (item.Bounds);
 
                 var text_bounds = new Rectangle (item.Bounds.Left, image_area_bounds.Bottom, item.Bounds.Width, item.Bounds.Bottom - image_area_bounds.Bottom);
-                canvas.DrawText (item.Text, Theme.UIFont, font_size, text_bounds, item.Enabled ? Theme.PrimaryTextColor : Theme.DisabledTextColor, ContentAlignment.MiddleCenter);
+                canvas.DrawText (item.Text, Theme.UIFont, font_size, text_bounds, item.Enabled ? Theme.ForegroundColor : Theme.ForegroundDisabledColor, ContentAlignment.MiddleCenter);
 
                 canvas.Restore ();
             }
@@ -91,13 +91,13 @@ namespace Modern.Forms.Renderers
         protected virtual void RenderMenuSeparatorItem (Ribbon control, RibbonTabPage tabPage, RibbonItemGroup group, MenuSeparatorItem item, PaintEventArgs e)
         {
             // Background
-            e.Canvas.FillRectangle (item.Bounds, Theme.NeutralGray);
+            e.Canvas.FillRectangle (item.Bounds, Theme.ControlMidColor);
 
             var center = item.Bounds.GetCenter ();
             var thickness = e.LogicalToDeviceUnits (1);
             var padding = e.LogicalToDeviceUnits (item.Padding);
 
-            e.Canvas.DrawLine (center.X, item.Bounds.Y + padding.Top, center.X, item.Bounds.Bottom - padding.Bottom, item.Enabled ? Theme.ItemHighlightColor : Theme.DisabledTextColor, thickness);
+            e.Canvas.DrawLine (center.X, item.Bounds.Y + padding.Top, center.X, item.Bounds.Bottom - padding.Bottom, item.Enabled ? Theme.ControlHighlightLowColor : Theme.ForegroundDisabledColor, thickness);
         }
 
         /// <summary>

--- a/src/Modern.Forms/Renderers/RibbonRenderer.cs
+++ b/src/Modern.Forms/Renderers/RibbonRenderer.cs
@@ -33,7 +33,7 @@ namespace Modern.Forms.Renderers
         {
             LayoutTabPage (tabPage);
 
-            e.Canvas.FillRectangle (tabPage.Bounds, Theme.ControlMidColor);
+            e.Canvas.FillRectangle (tabPage.Bounds, Theme.BackgroundColor);
 
             foreach (var group in tabPage.Groups)
                 RenderItemGroup (control, tabPage, group, e);
@@ -62,7 +62,7 @@ namespace Modern.Forms.Renderers
         {
             var canvas = e.Canvas;
             var padding = e.LogicalToDeviceUnits (item.Padding);
-            var background_color = item.Selected ? Theme.ControlHighlightMidColor : item.Hovered ? Theme.ControlHighlightLowColor : Theme.ControlMidColor;
+            var background_color = item.Selected ? Theme.ControlHighlightMidColor : item.Hovered ? Theme.ControlHighlightLowColor : Theme.BackgroundColor;
 
             canvas.FillRectangle (item.Bounds, background_color);
 
@@ -91,7 +91,7 @@ namespace Modern.Forms.Renderers
         protected virtual void RenderMenuSeparatorItem (Ribbon control, RibbonTabPage tabPage, RibbonItemGroup group, MenuSeparatorItem item, PaintEventArgs e)
         {
             // Background
-            e.Canvas.FillRectangle (item.Bounds, Theme.ControlMidColor);
+            e.Canvas.FillRectangle (item.Bounds, Theme.BackgroundColor);
 
             var center = item.Bounds.GetCenter ();
             var thickness = e.LogicalToDeviceUnits (1);

--- a/src/Modern.Forms/Renderers/ScrollBarRenderer.cs
+++ b/src/Modern.Forms/Renderers/ScrollBarRenderer.cs
@@ -30,14 +30,14 @@ namespace Modern.Forms.Renderers
             bottom_arrow_area.Height -= 1;
 
             // Top Arrow
-            e.Canvas.FillRectangle (top_arrow_area, Theme.ForegroundColorOnAccent);
+            e.Canvas.FillRectangle (top_arrow_area, Theme.ControlLowColor);
             e.Canvas.DrawRectangle (top_arrow_area, Theme.BorderLowColor);
-            ControlPaint.DrawArrowGlyph (e, top_arrow_area, Theme.BorderLowColor, GetDecrementArrowDirection (control));
+            ControlPaint.DrawArrowGlyph (e, top_arrow_area, Theme.ControlHighlightMidColor, GetDecrementArrowDirection (control));
 
             // Bottom Arrow
-            e.Canvas.FillRectangle (bottom_arrow_area, Theme.ForegroundColorOnAccent);
+            e.Canvas.FillRectangle (bottom_arrow_area, Theme.ControlLowColor);
             e.Canvas.DrawRectangle (bottom_arrow_area, Theme.BorderLowColor);
-            ControlPaint.DrawArrowGlyph (e, bottom_arrow_area, Theme.BorderLowColor, GetIncrementArrowDirection (control));
+            ControlPaint.DrawArrowGlyph (e, bottom_arrow_area, Theme.ControlHighlightMidColor, GetIncrementArrowDirection (control));
 
             if (!control.Enabled)
                 return;
@@ -46,7 +46,7 @@ namespace Modern.Forms.Renderers
             var thumb_bounds = GetThumbDragBounds (control);
 
             if (thumb_bounds.Width > 0 && thumb_bounds.Height > 0) {
-                e.Canvas.FillRectangle (thumb_bounds, SKColors.White);
+                e.Canvas.FillRectangle (thumb_bounds, Theme.ControlLowColor);
                 e.Canvas.DrawRectangle (thumb_bounds, Theme.BorderLowColor);
             }
         }

--- a/src/Modern.Forms/Renderers/ScrollBarRenderer.cs
+++ b/src/Modern.Forms/Renderers/ScrollBarRenderer.cs
@@ -30,14 +30,14 @@ namespace Modern.Forms.Renderers
             bottom_arrow_area.Height -= 1;
 
             // Top Arrow
-            e.Canvas.FillRectangle (top_arrow_area, SKColors.White);
-            e.Canvas.DrawRectangle (top_arrow_area, Theme.BorderGray);
-            ControlPaint.DrawArrowGlyph (e, top_arrow_area, Theme.BorderGray, GetDecrementArrowDirection (control));
+            e.Canvas.FillRectangle (top_arrow_area, Theme.ForegroundColorOnAccent);
+            e.Canvas.DrawRectangle (top_arrow_area, Theme.BorderLowColor);
+            ControlPaint.DrawArrowGlyph (e, top_arrow_area, Theme.BorderLowColor, GetDecrementArrowDirection (control));
 
             // Bottom Arrow
-            e.Canvas.FillRectangle (bottom_arrow_area, SKColors.White);
-            e.Canvas.DrawRectangle (bottom_arrow_area, Theme.BorderGray);
-            ControlPaint.DrawArrowGlyph (e, bottom_arrow_area, Theme.BorderGray, GetIncrementArrowDirection (control));
+            e.Canvas.FillRectangle (bottom_arrow_area, Theme.ForegroundColorOnAccent);
+            e.Canvas.DrawRectangle (bottom_arrow_area, Theme.BorderLowColor);
+            ControlPaint.DrawArrowGlyph (e, bottom_arrow_area, Theme.BorderLowColor, GetIncrementArrowDirection (control));
 
             if (!control.Enabled)
                 return;
@@ -47,7 +47,7 @@ namespace Modern.Forms.Renderers
 
             if (thumb_bounds.Width > 0 && thumb_bounds.Height > 0) {
                 e.Canvas.FillRectangle (thumb_bounds, SKColors.White);
-                e.Canvas.DrawRectangle (thumb_bounds, Theme.BorderGray);
+                e.Canvas.DrawRectangle (thumb_bounds, Theme.BorderLowColor);
             }
         }
 

--- a/src/Modern.Forms/Renderers/TabStripRenderer.cs
+++ b/src/Modern.Forms/Renderers/TabStripRenderer.cs
@@ -22,13 +22,13 @@ namespace Modern.Forms.Renderers
         {
             // Hover background
             if (item.Hovered && item.Enabled)
-                e.Canvas.FillRectangle (item.Bounds, Theme.LightNeutralGray);
+                e.Canvas.FillRectangle (item.Bounds, Theme.ControlLowColor);
 
             // Draw focus rectangle
             if (control.Selected && control.ShowFocusCues && control.Tabs.FocusedIndex == control.Tabs.IndexOf (item))
                 e.Canvas.DrawFocusRectangle (item.Bounds, e.LogicalToDeviceUnits (1));
 
-            var font_color = !item.Enabled ? Theme.DisabledTextColor : Theme.PrimaryTextColor;
+            var font_color = !item.Enabled ? Theme.ForegroundDisabledColor : Theme.ForegroundColor;
             var font = item.Selected || item.Hovered ? Theme.UIFontBold : Theme.UIFont;
             var font_size = e.LogicalToDeviceUnits (Theme.FontSize);
 
@@ -39,7 +39,7 @@ namespace Modern.Forms.Renderers
                 var highlight_height = e.LogicalToDeviceUnits (3);
                 var highlight_bounds = new Rectangle (item.Bounds.Left + highlight_padding, item.Bounds.Bottom - highlight_height, item.Bounds.Width - (2 * highlight_padding), highlight_height);
                 
-                e.Canvas.FillRectangle (highlight_bounds, Theme.PrimaryColor);
+                e.Canvas.FillRectangle (highlight_bounds, Theme.AccentColor2);
             }
         }
     }

--- a/src/Modern.Forms/Renderers/TabStripRenderer.cs
+++ b/src/Modern.Forms/Renderers/TabStripRenderer.cs
@@ -29,7 +29,7 @@ namespace Modern.Forms.Renderers
                 e.Canvas.DrawFocusRectangle (item.Bounds, e.LogicalToDeviceUnits (1));
 
             var font_color = !item.Enabled ? Theme.ForegroundDisabledColor : Theme.ForegroundColor;
-            var font = item.Selected || item.Hovered ? Theme.UIFontBold : Theme.UIFont;
+            var font = item.Enabled && (item.Selected || item.Hovered) ? Theme.UIFontBold : Theme.UIFont;
             var font_size = e.LogicalToDeviceUnits (Theme.FontSize);
 
             e.Canvas.DrawText (item.Text, font, font_size, item.Bounds, font_color, ContentAlignment.MiddleCenter);

--- a/src/Modern.Forms/Renderers/TextBoxRenderer.cs
+++ b/src/Modern.Forms/Renderers/TextBoxRenderer.cs
@@ -30,7 +30,7 @@ namespace Modern.Forms.Renderers
 
             if (control.Selected) {
                 var caret = TextMeasurer.GetCursorLocation (block, GetTextOrigin (control), GetCursorIndex (control), GetCurrentFontSize (control));
-                e.Canvas.DrawRectangle (caret, Theme.PrimaryTextColor);
+                e.Canvas.DrawRectangle (caret, Theme.ForegroundColor);
             }
 
             e.Canvas.Restore ();

--- a/src/Modern.Forms/Renderers/ToolBarRenderer.cs
+++ b/src/Modern.Forms/Renderers/ToolBarRenderer.cs
@@ -24,7 +24,7 @@ namespace Modern.Forms.Renderers
         protected virtual void RenderItem (ToolBar control, MenuItem item, PaintEventArgs e)
         {
             // Background
-            var background_color = item.Hovered || item.IsDropDownOpened ? Theme.ItemHighlightColor : Theme.NeutralGray;
+            var background_color = item.Hovered || item.IsDropDownOpened ? Theme.ControlHighlightLowColor : Theme.ControlMidColor;
             e.Canvas.FillRectangle (item.Bounds, background_color);
 
             var bounds = item.Bounds;
@@ -43,7 +43,7 @@ namespace Modern.Forms.Renderers
             }
 
             // Text
-            var font_color = item.Enabled ? Theme.PrimaryTextColor : Theme.DisabledTextColor;
+            var font_color = item.Enabled ? Theme.ForegroundColor : Theme.ForegroundDisabledColor;
             var font_size = e.LogicalToDeviceUnits (Theme.FontSize);
 
             bounds.Y += 1;
@@ -64,13 +64,13 @@ namespace Modern.Forms.Renderers
         protected virtual void RenderMenuSeparatorItem (ToolBar control, MenuSeparatorItem item, PaintEventArgs e)
         {
             // Background
-            e.Canvas.FillRectangle (item.Bounds, Theme.NeutralGray);
+            e.Canvas.FillRectangle (item.Bounds, Theme.ControlMidColor);
 
             var center = item.Bounds.GetCenter ();
             var thickness = e.LogicalToDeviceUnits (1);
             var padding = e.LogicalToDeviceUnits (item.Padding);
 
-            e.Canvas.DrawLine (center.X, item.Bounds.Top + padding.Top + thickness, center.X, item.Bounds.Bottom - padding.Bottom - thickness, item.Enabled ? Theme.ItemHighlightColor : Theme.DisabledTextColor, thickness);
+            e.Canvas.DrawLine (center.X, item.Bounds.Top + padding.Top + thickness, center.X, item.Bounds.Bottom - padding.Bottom - thickness, item.Enabled ? Theme.ControlHighlightLowColor : Theme.ForegroundDisabledColor, thickness);
         }
 
         /// <summary>

--- a/src/Modern.Forms/Renderers/ToolBarRenderer.cs
+++ b/src/Modern.Forms/Renderers/ToolBarRenderer.cs
@@ -24,7 +24,7 @@ namespace Modern.Forms.Renderers
         protected virtual void RenderItem (ToolBar control, MenuItem item, PaintEventArgs e)
         {
             // Background
-            var background_color = item.Hovered || item.IsDropDownOpened ? Theme.ControlHighlightLowColor : Theme.ControlMidColor;
+            var background_color = item.Hovered || item.IsDropDownOpened ? Theme.ControlHighlightLowColor : Theme.BackgroundColor;
             e.Canvas.FillRectangle (item.Bounds, background_color);
 
             var bounds = item.Bounds;
@@ -64,7 +64,7 @@ namespace Modern.Forms.Renderers
         protected virtual void RenderMenuSeparatorItem (ToolBar control, MenuSeparatorItem item, PaintEventArgs e)
         {
             // Background
-            e.Canvas.FillRectangle (item.Bounds, Theme.ControlMidColor);
+            e.Canvas.FillRectangle (item.Bounds, Theme.BackgroundColor);
 
             var center = item.Bounds.GetCenter ();
             var thickness = e.LogicalToDeviceUnits (1);

--- a/src/Modern.Forms/Renderers/TreeViewRenderer.cs
+++ b/src/Modern.Forms/Renderers/TreeViewRenderer.cs
@@ -43,7 +43,7 @@ namespace Modern.Forms.Renderers
         protected virtual void RenderItem (TreeView control, TreeViewItem item, PaintEventArgs e)
         {
             var is_selected = item == control.SelectedItem;
-            var foreground_color = control.Enabled ? Theme.PrimaryTextColor : Theme.DisabledTextColor;
+            var foreground_color = control.Enabled ? Theme.ForegroundColor : Theme.ForegroundDisabledColor;
 
             if (is_selected)
                 e.Canvas.FillRectangle (item.Bounds, control.Style.GetSelectedItemBackgroundColor ());

--- a/src/Modern.Forms/Ribbon.cs
+++ b/src/Modern.Forms/Ribbon.cs
@@ -36,7 +36,6 @@ namespace Modern.Forms
         /// <inheritdoc/>
         public new static ControlStyle DefaultStyle = new ControlStyle (Control.DefaultStyle, 
             (style) => {
-                style.BackgroundColor = Theme.AccentColor2;
                 style.Border.Bottom.Width = 1;
             });
 

--- a/src/Modern.Forms/Ribbon.cs
+++ b/src/Modern.Forms/Ribbon.cs
@@ -36,7 +36,7 @@ namespace Modern.Forms
         /// <inheritdoc/>
         public new static ControlStyle DefaultStyle = new ControlStyle (Control.DefaultStyle, 
             (style) => {
-                style.BackgroundColor = Theme.PrimaryColor;
+                style.BackgroundColor = Theme.AccentColor2;
                 style.Border.Bottom.Width = 1;
             });
 

--- a/src/Modern.Forms/ScrollBar.cs
+++ b/src/Modern.Forms/ScrollBar.cs
@@ -32,7 +32,7 @@ namespace Modern.Forms
 
         /// <inheritdoc/>
         public new static ControlStyle DefaultStyle = new ControlStyle (Control.DefaultStyle,
-            (style) => style.BackgroundColor = Theme.DarkNeutralGray);
+            (style) => style.BackgroundColor = Theme.ControlMidHighColor);
 
         /// <summary>
         /// Gets or sets the amount the ScrollBar will change when clicked in the track area.

--- a/src/Modern.Forms/TabStrip.cs
+++ b/src/Modern.Forms/TabStrip.cs
@@ -24,7 +24,7 @@ namespace Modern.Forms
         /// <inheritdoc/>
         public new static ControlStyle DefaultStyle = new ControlStyle (Control.DefaultStyle,
             (style) => {
-                style.BackgroundColor = Theme.NeutralGray;
+                style.BackgroundColor = Theme.BackgroundColor;
             });
 
         private int FindNextTab (int startIndex, bool forward, bool wrap)

--- a/src/Modern.Forms/TextBox.cs
+++ b/src/Modern.Forms/TextBox.cs
@@ -70,7 +70,7 @@ namespace Modern.Forms
         public new static ControlStyle DefaultStyle = new ControlStyle (Control.DefaultStyle,
             (style) => {
                 style.Border.Width = 1;
-                style.BackgroundColor = Theme.LightNeutralGray;
+                style.BackgroundColor = Theme.ControlLowColor;
             });
 
         // Scrolls the TextBox by the specified amounts.

--- a/src/Modern.Forms/TextBoxDocument.cs
+++ b/src/Modern.Forms/TextBoxDocument.cs
@@ -26,7 +26,7 @@ namespace Modern.Forms
         private int width = -1;
         private SKTypeface font = Theme.UIFont;
         private TextAlignment alignment = TextAlignment.Left;
-        private SKColor placeholder_font_color = Theme.DisabledTextColor;
+        private SKColor placeholder_font_color = Theme.ForegroundDisabledColor;
         private SKColor selection_color = new SKColor (153, 201, 239);
 
         private static readonly string[] invalid_singleline_characters = new[] { "\r", "\n" };
@@ -148,7 +148,7 @@ namespace Modern.Forms
                 return cached_text_block;
 
             var max_size = multiline ? new Size (width, int.MaxValue) : TextMeasurer.MaxSize;
-            var color = !Enabled ? Theme.DisabledTextColor :
+            var color = !Enabled ? Theme.ForegroundDisabledColor :
                         Text.HasValue () ? textbox.CurrentStyle.GetForegroundColor () : 
                                 placeholder_font_color;
 

--- a/src/Modern.Forms/Theme.cs
+++ b/src/Modern.Forms/Theme.cs
@@ -18,19 +18,7 @@ namespace Modern.Forms
 
         static Theme ()
         {
-            values[nameof (PrimaryColor)] = new SKColor (0, 120, 212);
-            values[nameof (PrimaryTextColor)] = SKColors.Black;
-            values[nameof (DisabledTextColor)] = new SKColor (190, 190, 190);
-            values[nameof (LightTextColor)] = SKColors.White;
-            values[nameof (FormBackgroundColor)] = new SKColor (240, 240, 240);
-            values[nameof (FormCloseHighlightColor)] = new SKColor (232, 17, 35);
-            values[nameof (HighlightColor)] = new SKColor (42, 138, 208);
-            values[nameof (ItemHighlightColor)] = new SKColor (198, 198, 198);
-            values[nameof (ItemSelectedColor)] = new SKColor (176, 176, 176);
-            values[nameof (DarkNeutralGray)] = new SKColor (225, 225, 225);
-            values[nameof (NeutralGray)] = new SKColor (243, 242, 241);
-            values[nameof (LightNeutralGray)] = new SKColor (251, 251, 251);
-            values[nameof (BorderGray)] = new SKColor (171, 171, 171);
+            SetBuiltInTheme (BuiltInTheme.Default);
 
             values[nameof (UIFont)] = SKTypeface.FromFamilyName ("Segoe UI Emoji", SKFontStyleWeight.Normal, SKFontStyleWidth.Normal, SKFontStyleSlant.Upright);
             values[nameof (UIFontBold)] = SKTypeface.FromFamilyName ("Segoe UI Emoji", SKFontStyleWeight.Bold, SKFontStyleWidth.Normal, SKFontStyleSlant.Upright);
@@ -181,6 +169,51 @@ namespace Modern.Forms
         public static SKColor PrimaryTextColor {
             get => GetValue<SKColor> (nameof (PrimaryTextColor));
             set => SetValue (nameof (PrimaryTextColor), value);
+        }
+
+        public static void SetBuiltInTheme (BuiltInTheme theme)
+        {
+            // We always reset the colors, even if we were already using the current theme.
+            // This resets any modification the user made, which feels like the expected behavior.
+
+            BeginUpdate ();
+
+            // TODO: BuiltInTheme.Default should detect the OS setting. Currently it just uses Light.
+            switch (theme) {
+                case BuiltInTheme.Dark:
+                    values[nameof (PrimaryColor)] = new SKColor (0, 120, 212);
+                    values[nameof (PrimaryTextColor)] = SKColors.White;
+                    values[nameof (DisabledTextColor)] = new SKColor (71, 71, 71);
+                    values[nameof (LightTextColor)] = SKColors.White;
+                    values[nameof (FormBackgroundColor)] = new SKColor (31, 31, 31);
+                    values[nameof (FormCloseHighlightColor)] = new SKColor (232, 17, 35);
+                    values[nameof (HighlightColor)] = new SKColor (42, 138, 208);
+                    values[nameof (ItemHighlightColor)] = new SKColor (45, 71, 101);
+                    values[nameof (ItemSelectedColor)] = new SKColor (176, 176, 176);
+                    values[nameof (DarkNeutralGray)] = new SKColor (225, 225, 225);
+                    values[nameof (NeutralGray)] = new SKColor (37, 37, 38);
+                    values[nameof (LightNeutralGray)] = new SKColor (31, 31, 31);
+                    values[nameof (BorderGray)] = new SKColor (61, 61, 61);
+                    break;
+                default:
+                    values[nameof (PrimaryColor)] = new SKColor (0, 120, 212);
+                    values[nameof (PrimaryTextColor)] = SKColors.Black;
+                    values[nameof (DisabledTextColor)] = new SKColor (190, 190, 190);
+                    values[nameof (LightTextColor)] = SKColors.White;
+                    values[nameof (FormBackgroundColor)] = new SKColor (240, 240, 240);
+                    values[nameof (FormCloseHighlightColor)] = new SKColor (232, 17, 35);
+                    values[nameof (HighlightColor)] = new SKColor (42, 138, 208);
+                    values[nameof (ItemHighlightColor)] = new SKColor (198, 198, 198);
+                    values[nameof (ItemSelectedColor)] = new SKColor (176, 176, 176);
+                    values[nameof (DarkNeutralGray)] = new SKColor (225, 225, 225);
+                    values[nameof (NeutralGray)] = new SKColor (243, 242, 241);
+                    values[nameof (LightNeutralGray)] = new SKColor (251, 251, 251);
+                    values[nameof (BorderGray)] = new SKColor (171, 171, 171);
+                    break;
+            }
+
+            RaiseThemeChanged ();
+            EndUpdate ();
         }
 
         private static void RaiseThemeChanged ()

--- a/src/Modern.Forms/Theme.cs
+++ b/src/Modern.Forms/Theme.cs
@@ -236,7 +236,7 @@ namespace Modern.Forms
                     values[nameof (ControlHighlightMidColor)] = SKColor.Parse ("#FF828282");
                     values[nameof (ControlHighlightHighColor)] = SKColor.Parse ("#FF505050");
                     values[nameof (ForegroundColor)] = SKColor.Parse ("#FFDEDEDE");
-                    values[nameof (ForegroundDisabledColor)] = new SKColor (71, 71, 71);
+                    values[nameof (ForegroundDisabledColor)] = new SKColor (150, 150, 150);
                     values[nameof (ForegroundColorOnAccent)] = SKColors.White;
                     values[nameof (AccentColor)] = SKColor.Parse ("#FF096085");
                     values[nameof (AccentColor2)] = new SKColor (0, 120, 212);
@@ -256,7 +256,7 @@ namespace Modern.Forms
                     values[nameof (ControlHighlightMidColor)] = SKColor.Parse ("#FFB0B0B0");
                     values[nameof (ControlHighlightHighColor)] = SKColor.Parse ("#FF808080");
                     values[nameof (ForegroundColor)] = SKColor.Parse ("#FF000000");
-                    values[nameof (ForegroundDisabledColor)] = new SKColor (190, 190, 190);
+                    values[nameof (ForegroundDisabledColor)] = new SKColor (170, 170, 170);
                     values[nameof (ForegroundColorOnAccent)] = SKColors.White;
                     values[nameof (AccentColor)] = new SKColor (42, 138, 208);
                     values[nameof (AccentColor2)] = new SKColor (0, 120, 212);

--- a/src/Modern.Forms/Theme.cs
+++ b/src/Modern.Forms/Theme.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Drawing;
-using System.Text;
 using SkiaSharp;
 
 namespace Modern.Forms
@@ -27,6 +25,30 @@ namespace Modern.Forms
         }
 
         /// <summary>
+        /// The primary color uses for accents.
+        /// </summary>
+        public static SKColor AccentColor {
+            get => GetValue<SKColor> (nameof (AccentColor));
+            set => SetValue (nameof (AccentColor), value);
+        }
+
+        /// <summary>
+        /// The secondary color uses for accents.
+        /// </summary>
+        public static SKColor AccentColor2 {
+            get => GetValue<SKColor> (nameof (AccentColor2));
+            set => SetValue (nameof (AccentColor2), value);
+        }
+
+        /// <summary>
+        /// The default background color of a Form and Control.
+        /// </summary>
+        public static SKColor BackgroundColor {
+            get => GetValue<SKColor> (nameof (BackgroundColor));
+            set => SetValue (nameof (BackgroundColor), value);
+        }
+
+        /// <summary>
         /// Pause raising ThemeChanged for better performance if changing many Theme elements.
         /// Resume with EndUpdate ().
         /// </summary>
@@ -36,27 +58,91 @@ namespace Modern.Forms
         }
 
         /// <summary>
-        /// A darker gray used as the default control border color.
+        /// The low color used for Control borders.
         /// </summary>
-        public static SKColor BorderGray {
-            get => GetValue<SKColor> (nameof (BorderGray));
-            set => SetValue (nameof (BorderGray), value);
+        public static SKColor BorderLowColor {
+            get => GetValue<SKColor> (nameof (BorderLowColor));
+            set => SetValue (nameof (BorderLowColor), value);
         }
 
         /// <summary>
-        /// A darker gray generally used for showing an item is currently pressed.
+        /// The mid color used for Control borders.
         /// </summary>
-        public static SKColor DarkNeutralGray {
-            get => GetValue<SKColor> (nameof (DarkNeutralGray));
-            set => SetValue (nameof (DarkNeutralGray), value);
+        public static SKColor BorderMidColor {
+            get => GetValue<SKColor> (nameof (BorderMidColor));
+            set => SetValue (nameof (BorderMidColor), value);
         }
 
         /// <summary>
-        /// The color used for disabled text.
+        /// The high color used for Control borders.
         /// </summary>
-        public static SKColor DisabledTextColor {
-            get => GetValue<SKColor> (nameof (DisabledTextColor));
-            set => SetValue (nameof (DisabledTextColor), value);
+        public static SKColor BorderHighColor {
+            get => GetValue<SKColor> (nameof (BorderHighColor));
+            set => SetValue (nameof (BorderHighColor), value);
+        }
+
+        /// <summary>
+        /// The low color used for Controls.
+        /// </summary>
+        public static SKColor ControlLowColor {
+            get => GetValue<SKColor> (nameof (ControlLowColor));
+            set => SetValue (nameof (ControlLowColor), value);
+        }
+
+        /// <summary>
+        /// The mid color used for Controls.
+        /// </summary>
+        public static SKColor ControlMidColor {
+            get => GetValue<SKColor> (nameof (ControlMidColor));
+            set => SetValue (nameof (ControlMidColor), value);
+        }
+
+        /// <summary>
+        /// The mid-high color used for Controls.
+        /// </summary>
+        public static SKColor ControlMidHighColor {
+            get => GetValue<SKColor> (nameof (ControlMidHighColor));
+            set => SetValue (nameof (ControlMidHighColor), value);
+        }
+
+        /// <summary>
+        /// The high color used for Controls.
+        /// </summary>
+        public static SKColor ControlHighColor {
+            get => GetValue<SKColor> (nameof (ControlHighColor));
+            set => SetValue (nameof (ControlHighColor), value);
+        }
+
+        /// <summary>
+        /// The very high color used for Controls.
+        /// </summary>
+        public static SKColor ControlVeryHighColor {
+            get => GetValue<SKColor> (nameof (ControlVeryHighColor));
+            set => SetValue (nameof (ControlVeryHighColor), value);
+        }
+
+        /// <summary>
+        /// The low color used for highlighted elements, like hovered tabs or buttons.
+        /// </summary>
+        public static SKColor ControlHighlightLowColor {
+            get => GetValue<SKColor> (nameof (ControlHighlightLowColor));
+            set => SetValue (nameof (ControlHighlightLowColor), value);
+        }
+
+        /// <summary>
+        /// The mid color used for highlighted elements, like hovered tabs or buttons.
+        /// </summary>
+        public static SKColor ControlHighlightMidColor {
+            get => GetValue<SKColor> (nameof (ControlHighlightMidColor));
+            set => SetValue (nameof (ControlHighlightMidColor), value);
+        }
+
+        /// <summary>
+        /// The high color used for highlighted elements, like hovered tabs or buttons.
+        /// </summary>
+        public static SKColor ControlHighlightHighColor {
+            get => GetValue<SKColor> (nameof (ControlHighlightHighColor));
+            set => SetValue (nameof (ControlHighlightHighColor), value);
         }
 
         /// <summary>
@@ -82,30 +168,30 @@ namespace Modern.Forms
         }
 
         /// <summary>
-        /// The background color of a form.
+        /// The foreground color used for text.
         /// </summary>
-        public static SKColor FormBackgroundColor {
-            get => GetValue<SKColor> (nameof (FormBackgroundColor));
-            set => SetValue (nameof (FormBackgroundColor), value);
+        public static SKColor ForegroundColor {
+            get => GetValue<SKColor> (nameof (ForegroundColor));
+            set => SetValue (nameof (ForegroundColor), value);
         }
 
         /// <summary>
-        /// The color used to draw a form's close button when highlighted.
+        /// A text color that is visible on an AccentColor background.
         /// </summary>
-        public static SKColor FormCloseHighlightColor {
-            get => GetValue<SKColor> (nameof (FormCloseHighlightColor));
-            set => SetValue (nameof (FormCloseHighlightColor), value);
+        public static SKColor ForegroundColorOnAccent {
+            get => GetValue<SKColor> (nameof (ForegroundColorOnAccent));
+            set => SetValue (nameof (ForegroundColorOnAccent), value);
+        }
+
+        /// <summary>
+        /// The color used for disabled text.
+        /// </summary>
+        public static SKColor ForegroundDisabledColor {
+            get => GetValue<SKColor> (nameof (ForegroundDisabledColor));
+            set => SetValue (nameof (ForegroundDisabledColor), value);
         }
 
         private static T GetValue<T> (string name) => (T)values[name];
-
-        /// <summary>
-        /// The color used for highlighted elements, like hovered tabs or buttons.
-        /// </summary>
-        public static SKColor HighlightColor {
-            get => GetValue<SKColor> (nameof (HighlightColor));
-            set => SetValue (nameof (HighlightColor), value);
-        }
 
         /// <summary>
         /// A smaller font size generally used for lists of items.
@@ -116,61 +202,17 @@ namespace Modern.Forms
         }
 
         /// <summary>
-        /// The color used for a highlighted item's background.
+        /// The color used to highlight a potentially destructive action.
         /// </summary>
-        public static SKColor ItemHighlightColor {
-            get => GetValue<SKColor> (nameof (ItemHighlightColor));
-            set => SetValue (nameof (ItemHighlightColor), value);
+        public static SKColor WarningHighlightColor {
+            get => GetValue<SKColor> (nameof (WarningHighlightColor));
+            set => SetValue (nameof (WarningHighlightColor), value);
         }
 
         /// <summary>
-        /// The color used for a selected item's background.
+        /// Changes or resets the application theme to a set of built-in defaults.
         /// </summary>
-        public static SKColor ItemSelectedColor {
-            get => GetValue<SKColor> (nameof (ItemSelectedColor));
-            set => SetValue (nameof (ItemSelectedColor), value);
-        }
-
-        /// <summary>
-        /// A lighter gray used primarily used as the background of list items.
-        /// </summary>
-        public static SKColor LightNeutralGray {
-            get => GetValue<SKColor> (nameof (LightNeutralGray));
-            set => SetValue (nameof (LightNeutralGray), value);
-        }
-
-        /// <summary>
-        /// A lighter text color, often used when an element is selected with a darker background.
-        /// </summary>
-        public static SKColor LightTextColor {
-            get => GetValue<SKColor> (nameof (LightTextColor));
-            set => SetValue (nameof (LightTextColor), value);
-        }
-
-        /// <summary>
-        /// A neutral gray used as the default background of controls.
-        /// </summary>
-        public static SKColor NeutralGray {
-            get => GetValue<SKColor> (nameof (NeutralGray));
-            set => SetValue (nameof (NeutralGray), value);
-        }
-
-        /// <summary>
-        /// The primary color for elements such as the title bar, tabs, checkboxes and radio button glyph.
-        /// </summary>
-        public static SKColor PrimaryColor {
-            get => GetValue<SKColor> (nameof (PrimaryColor));
-            set => SetValue (nameof (PrimaryColor), value);
-        }
-
-        /// <summary>
-        /// The primary text color.
-        /// </summary>
-        public static SKColor PrimaryTextColor {
-            get => GetValue<SKColor> (nameof (PrimaryTextColor));
-            set => SetValue (nameof (PrimaryTextColor), value);
-        }
-
+        /// <param name="theme"></param>
         public static void SetBuiltInTheme (BuiltInTheme theme)
         {
             // We always reset the colors, even if we were already using the current theme.
@@ -181,34 +223,44 @@ namespace Modern.Forms
             // TODO: BuiltInTheme.Default should detect the OS setting. Currently it just uses Light.
             switch (theme) {
                 case BuiltInTheme.Dark:
-                    values[nameof (PrimaryColor)] = new SKColor (0, 120, 212);
-                    values[nameof (PrimaryTextColor)] = SKColors.White;
-                    values[nameof (DisabledTextColor)] = new SKColor (71, 71, 71);
-                    values[nameof (LightTextColor)] = SKColors.White;
-                    values[nameof (FormBackgroundColor)] = new SKColor (31, 31, 31);
-                    values[nameof (FormCloseHighlightColor)] = new SKColor (232, 17, 35);
-                    values[nameof (HighlightColor)] = new SKColor (42, 138, 208);
-                    values[nameof (ItemHighlightColor)] = new SKColor (45, 71, 101);
-                    values[nameof (ItemSelectedColor)] = new SKColor (176, 176, 176);
-                    values[nameof (DarkNeutralGray)] = new SKColor (225, 225, 225);
-                    values[nameof (NeutralGray)] = new SKColor (37, 37, 38);
-                    values[nameof (LightNeutralGray)] = new SKColor (31, 31, 31);
-                    values[nameof (BorderGray)] = new SKColor (61, 61, 61);
+                    values[nameof (BackgroundColor)] = SKColor.Parse ("#FF282828");
+                    values[nameof (BorderLowColor)] = SKColor.Parse ("#FF505050");
+                    values[nameof (BorderMidColor)] = SKColor.Parse ("#FF808080");
+                    values[nameof (BorderHighColor)] = SKColor.Parse ("#FFA0A0A0");
+                    values[nameof (ControlLowColor)] = SKColor.Parse ("#FF282828");
+                    values[nameof (ControlMidColor)] = SKColor.Parse ("#FF505050");
+                    values[nameof (ControlMidHighColor)] = SKColor.Parse ("#FF686868");
+                    values[nameof (ControlHighColor)] = SKColor.Parse ("#FF808080");
+                    values[nameof (ControlVeryHighColor)] = SKColor.Parse ("#FFEFEBEF");
+                    values[nameof (ControlHighlightLowColor)] = SKColor.Parse ("#FFA8A8A8");
+                    values[nameof (ControlHighlightMidColor)] = SKColor.Parse ("#FF828282");
+                    values[nameof (ControlHighlightHighColor)] = SKColor.Parse ("#FF505050");
+                    values[nameof (ForegroundColor)] = SKColor.Parse ("#FFDEDEDE");
+                    values[nameof (ForegroundDisabledColor)] = new SKColor (71, 71, 71);
+                    values[nameof (ForegroundColorOnAccent)] = SKColors.White;
+                    values[nameof (AccentColor)] = SKColor.Parse ("#FF096085");
+                    values[nameof (AccentColor2)] = new SKColor (0, 120, 212);
+                    values[nameof (WarningHighlightColor)] = new SKColor (232, 17, 35);
                     break;
                 default:
-                    values[nameof (PrimaryColor)] = new SKColor (0, 120, 212);
-                    values[nameof (PrimaryTextColor)] = SKColors.Black;
-                    values[nameof (DisabledTextColor)] = new SKColor (190, 190, 190);
-                    values[nameof (LightTextColor)] = SKColors.White;
-                    values[nameof (FormBackgroundColor)] = new SKColor (240, 240, 240);
-                    values[nameof (FormCloseHighlightColor)] = new SKColor (232, 17, 35);
-                    values[nameof (HighlightColor)] = new SKColor (42, 138, 208);
-                    values[nameof (ItemHighlightColor)] = new SKColor (198, 198, 198);
-                    values[nameof (ItemSelectedColor)] = new SKColor (176, 176, 176);
-                    values[nameof (DarkNeutralGray)] = new SKColor (225, 225, 225);
-                    values[nameof (NeutralGray)] = new SKColor (243, 242, 241);
-                    values[nameof (LightNeutralGray)] = new SKColor (251, 251, 251);
-                    values[nameof (BorderGray)] = new SKColor (171, 171, 171);
+                    values[nameof (BackgroundColor)] = new SKColor (240, 240, 240);
+                    values[nameof (BorderLowColor)] = SKColor.Parse ("#FFABABAB");
+                    values[nameof (BorderMidColor)] = SKColor.Parse ("#FF808080");
+                    values[nameof (BorderHighColor)] = SKColor.Parse ("#FF333333");
+                    values[nameof (ControlLowColor)] = SKColor.Parse ("#FFFBFBFB");
+                    values[nameof (ControlMidColor)] = SKColor.Parse ("#FFF3F3F3");
+                    values[nameof (ControlMidHighColor)] = SKColor.Parse ("#FFE1E1E1");
+                    values[nameof (ControlHighColor)] = SKColor.Parse ("#FFC2C3C9");
+                    values[nameof (ControlVeryHighColor)] = SKColor.Parse ("#FF686868");
+                    values[nameof (ControlHighlightLowColor)] = SKColor.Parse ("#FFC6C6C6");
+                    values[nameof (ControlHighlightMidColor)] = SKColor.Parse ("#FFB0B0B0");
+                    values[nameof (ControlHighlightHighColor)] = SKColor.Parse ("#FF808080");
+                    values[nameof (ForegroundColor)] = SKColor.Parse ("#FF000000");
+                    values[nameof (ForegroundDisabledColor)] = new SKColor (190, 190, 190);
+                    values[nameof (ForegroundColorOnAccent)] = SKColors.White;
+                    values[nameof (AccentColor)] = new SKColor (42, 138, 208);
+                    values[nameof (AccentColor2)] = new SKColor (0, 120, 212);
+                    values[nameof (WarningHighlightColor)] = new SKColor (232, 17, 35);
                     break;
             }
 

--- a/src/Modern.Forms/ToolBar.cs
+++ b/src/Modern.Forms/ToolBar.cs
@@ -23,7 +23,7 @@ namespace Modern.Forms
         /// <inheritdoc/>
         public new static ControlStyle DefaultStyle = new ControlStyle (Control.DefaultStyle,
           (style) => {
-              style.BackgroundColor = Theme.NeutralGray;
+              style.BackgroundColor = Theme.ControlMidColor;
               style.Border.Bottom.Width = 1;
           });
 

--- a/src/Modern.Forms/ToolBar.cs
+++ b/src/Modern.Forms/ToolBar.cs
@@ -23,7 +23,6 @@ namespace Modern.Forms
         /// <inheritdoc/>
         public new static ControlStyle DefaultStyle = new ControlStyle (Control.DefaultStyle,
           (style) => {
-              style.BackgroundColor = Theme.ControlMidColor;
               style.Border.Bottom.Width = 1;
           });
 

--- a/src/Modern.Forms/TreeView.cs
+++ b/src/Modern.Forms/TreeView.cs
@@ -55,11 +55,11 @@ namespace Modern.Forms
         /// <inheritdoc/>
         public new static TreeViewControlStyle DefaultStyle = new TreeViewControlStyle (Control.DefaultStyle,
             (style) => {
-                style.BackgroundColor = Theme.LightNeutralGray;
+                style.BackgroundColor = Theme.ControlLowColor;
                 style.Border.Width = 1;
 
                 if (style is TreeViewControlStyle s)
-                    s.SelectedItemBackgroundColor = Theme.ItemHighlightColor;
+                    s.SelectedItemBackgroundColor = Theme.ControlHighlightLowColor;
             });
 
         /// <inheritdoc/>
@@ -524,7 +524,7 @@ namespace Modern.Forms
             /// <summary>
             /// Gets the computed selected item background color.
             /// </summary>
-            public SKColor GetSelectedItemBackgroundColor () => SelectedItemBackgroundColor ?? (_parent as TreeViewControlStyle)?.GetSelectedItemBackgroundColor () ?? Theme.ItemHighlightColor;
+            public SKColor GetSelectedItemBackgroundColor () => SelectedItemBackgroundColor ?? (_parent as TreeViewControlStyle)?.GetSelectedItemBackgroundColor () ?? Theme.ControlHighlightLowColor;
         }
     }
 }

--- a/src/Modern.Forms/WindowBase.cs
+++ b/src/Modern.Forms/WindowBase.cs
@@ -45,6 +45,8 @@ namespace Modern.Forms
                 Application.ActiveMenu?.Deactivate ();
                 Deactivated?.Invoke (this, EventArgs.Empty);
             };
+
+            Theme.ThemeChanged += (o, e) => Invalidate ();
         }
 
         /// <summary>

--- a/src/Modern.Forms/WindowBase.cs
+++ b/src/Modern.Forms/WindowBase.cs
@@ -121,7 +121,7 @@ namespace Modern.Forms
         /// </summary>
         public static ControlStyle DefaultStyle = new ControlStyle (Control.DefaultStyle,
          (style) => {
-             style.BackgroundColor = Theme.FormBackgroundColor;
+             style.BackgroundColor = Theme.BackgroundColor;
          });
 
         /// <summary>


### PR DESCRIPTION
Begin porting Dark theme improvements from https://github.com/dax-leo/Modern.Forms.Toolkit.

Checklist:

- [x] Infrastructure for switching themes
- [x] Controls render well with Light theme
- [x] Controls render well with Dark theme

Given that some of the Theme color property names no longer make sense in a Dark theme, they have all been renamed to something more theme agnostic.  This is largely borrowed from Avalonia's naming.