### PR TITLE
[ScrollableControl] DisplayRectangle should be unscaled values.

### DIFF
--- a/src/Modern.Forms/ScrollableControl.cs
+++ b/src/Modern.Forms/ScrollableControl.cs
@@ -120,7 +120,7 @@ namespace Modern.Forms
         public override Rectangle DisplayRectangle {
             get {
                 // A ScrollableControl DisplayRectangle includes Padding, while a normal Control does not.
-                var rect = ClientRectangle;
+                var rect = base.DisplayRectangle;
 
                 if (hscrollbar.Visible)
                     rect.Height -= hscrollbar.Height;


### PR DESCRIPTION
Fixes #51

`ScrollableControl` overrides `Control.DisplayRectangle` to remove additional space for scrollbars and padding.  However by using `ClientRectangle` it was calculating a _scaled_ size instead of an _unscaled_ size.  This meant on a 200% DPI system the total area was 4X the expected size.

Because `DisplayRectangle` is the size measurement used by the layout system, controls that were docked in this control were sized at 4X.  If they themselves were `ScrollableControl`s then they would be 4X also, resulting in 16X, etc.

This causes enormous Skia buffers to be allocated, resulting in absurd memory usage on HiDPI machines.

Fix to be an unscaled size.