### PR TITLE
[ComboBox] Close dropdown on mouse up instead of mouse down.

### DIFF
--- a/src/Modern.Forms/ComboBox.cs
+++ b/src/Modern.Forms/ComboBox.cs
@@ -18,7 +18,7 @@ namespace Modern.Forms
         /// </summary>
         public ComboBox ()
         {
-            popup_listbox = new ListBox { Dock = DockStyle.Fill, ShowHover = true };
+            popup_listbox = new ListBox { Dock = DockStyle.Fill, SelectItemOnMouseUp = true, ShowHover = true };
             popup_listbox.SelectedIndexChanged += ListBox_SelectedIndexChanged;
         }
 

--- a/src/Modern.Forms/ListBox.cs
+++ b/src/Modern.Forms/ListBox.cs
@@ -313,10 +313,8 @@ namespace Modern.Forms
             base.OnKeyUp (e);
         }
 
-        /// <inheritdoc/>
-        protected override void OnMouseDown (MouseEventArgs e)
+        private void OnMouseButtonLogic (MouseEventArgs e)
         {
-            base.OnMouseDown (e);
 
             if (!Enabled || !e.Button.HasFlag (MouseButtons.Left))
                 return;
@@ -355,6 +353,24 @@ namespace Modern.Forms
             }
 
             EnsureItemVisible (index);
+        }
+
+        /// <inheritdoc/>
+        protected override void OnMouseDown (MouseEventArgs e)
+        {
+            base.OnMouseDown (e);
+
+            if (!SelectItemOnMouseUp)
+                OnMouseButtonLogic (e);
+        }
+
+        /// <inheritdoc/>
+        protected override void OnMouseUp (MouseEventArgs e)
+        {
+            base.OnMouseUp (e);
+
+            if (SelectItemOnMouseUp)
+                OnMouseButtonLogic (e);
         }
 
         /// <inheritdoc/>
@@ -470,6 +486,11 @@ namespace Modern.Forms
                     Items.SelectedIndex = Items.SelectedIndex;  // Yes this does something  ;)
             }
         }
+
+        // By default, we select the item in MouseDown. However, when used in a ComboBox,
+        // we need to select the item in MouseUp, or else the popup will close and the MouseUp
+        // event will leak to the control/form beneath the popup.
+        internal bool SelectItemOnMouseUp { get; set; }
 
         /// <inheritdoc/>
         protected override void SetBoundsCore (int x, int y, int width, int height, BoundsSpecified specified)


### PR DESCRIPTION
Fixes https://github.com/modern-forms/Modern.Forms/issues/87

The `ListBox` used in a `ComboBox` raises its `SelectedIndexChanged` on `MouseDown`, which closes the `ComboBox` dropdown.  This causes the subsequent `MouseUp` event to be processed by the `Form`/`Control` that was underneath the `ComboBox` which is not desired.

Allow the `ComboBox` to set an internal property on the `ListBox` that tells it to change the `SelectedIndexChanged` event on `MouseUp` instead.  This appears to match Winforms behavior better as well.