### PR TITLE
Update Linux OS version in GitHub Actions workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-20.04]
+        os: [macos-latest, windows-latest, ubuntu-latest]
       fail-fast: false
     
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
It looks like `ubuntu-20.04` no longer has much capacity and are queued for long periods before running.